### PR TITLE
[FIX] dev script on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"prebuild": "rimraf dist out",
 		"build": "tsc -p ./tsconfig.src.json",
 		"predev": "rimraf dist out",
-		"dev": "tsc-watch -p ./tsconfig.src.json --onSuccess 'node --enable-source-maps ./dist/index --watch'",
+		"dev": "tsc-watch -p ./tsconfig.src.json --onSuccess \"node --enable-source-maps ./dist/index --watch\"",
 		"start": "node --enable-source-maps ./dist/index",
 		"lint": "eslint --max-warnings 0 .",
 		"lint:fix": "eslint --fix .",


### PR DESCRIPTION
Because Windows doesn't respect single quotes.