### PR TITLE
[DEV] Add hook to prevent pushing to master

### DIFF
--- a/.hooks/pre-push
+++ b/.hooks/pre-push
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+set -eou pipefail
+source "./.hooks/include.sh"
+
+REMOTE_NAME="$1"
+REMOTE_URL="$2"
+
+# Allow manually bypassing the restrictions
+if [ "${ALLOW_MASTER_PUSH:-}" == "true" ]; then
+	exit 0
+fi
+
+if [[ ! "$REMOTE_URL" =~ 'github.com'.*'Project-Pandora-Game/pandora'.* ]]; then
+	# This is not official repo, no check (forks need to be able to push master to sync)
+	exit 0
+fi
+
+while read local_ref local_sha remote_ref remote_sha
+do
+	# Check that `master` is not being pushed from any branch
+	if [ "$remote_ref" = "refs/heads/master" ]; then
+		echo "Pushing to branch \"master\" is forbidden"
+		exit 1
+	fi
+done
+
+exit 0


### PR DESCRIPTION
Adds a `pre-push` hook that prevents pushing to `master`, even if you try pushing to master from a different branch.