### PR TITLE
[DEV] Ignore pandora submodule when updating dependencies

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
+include-workspace-root=true
 strict-peer-dependencies=true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,81 +4,83 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-dependencies:
-  dotenv:
-    specifier: 16.3.1
-    version: 16.3.1
-  jimp:
-    specifier: 0.22.10
-    version: 0.22.10
-  lodash:
-    specifier: 4.17.21
-    version: 4.17.21
-  pandora-common:
-    specifier: file:pandora/pandora-common
-    version: file:pandora/pandora-common
-  rimraf:
-    specifier: 5.0.1
-    version: 5.0.1
-  sharp:
-    specifier: 0.32.5
-    version: 0.32.5
-  simple-git:
-    specifier: 3.19.1
-    version: 3.19.1
-  zod:
-    specifier: 3.22.2
-    version: 3.22.2
+importers:
 
-devDependencies:
-  '@types/express':
-    specifier: 4.17.17
-    version: 4.17.17
-  '@types/jest':
-    specifier: 29.5.4
-    version: 29.5.4
-  '@types/lodash':
-    specifier: 4.14.198
-    version: 4.14.198
-  '@types/node':
-    specifier: 18.17.15
-    version: 18.17.15
-  '@types/sharp':
-    specifier: 0.31.1
-    version: 0.31.1
-  '@typescript-eslint/eslint-plugin':
-    specifier: 6.7.0
-    version: 6.7.0(@typescript-eslint/parser@6.7.0)(eslint@8.49.0)(typescript@5.2.2)
-  '@typescript-eslint/parser':
-    specifier: 6.7.0
-    version: 6.7.0(eslint@8.49.0)(typescript@5.2.2)
-  eslint:
-    specifier: 8.49.0
-    version: 8.49.0
-  express:
-    specifier: 4.18.2
-    version: 4.18.2
-  immer:
-    specifier: ^10.0.2
-    version: 10.0.2
-  jest:
-    specifier: 29.7.0
-    version: 29.7.0(@types/node@18.17.15)
-  ts-jest:
-    specifier: 29.1.1
-    version: 29.1.1(@babel/core@7.21.3)(jest@29.7.0)(typescript@5.2.2)
-  ts-mockito:
-    specifier: 2.6.1
-    version: 2.6.1
-  tsc-watch:
-    specifier: 6.0.4
-    version: 6.0.4(typescript@5.2.2)
-  tslib:
-    specifier: 2.6.2
-    version: 2.6.2
-  typescript:
-    specifier: 5.2.2
-    version: 5.2.2
+  .:
+    dependencies:
+      dotenv:
+        specifier: 16.3.1
+        version: 16.3.1
+      jimp:
+        specifier: 0.22.10
+        version: 0.22.10
+      lodash:
+        specifier: 4.17.21
+        version: 4.17.21
+      pandora-common:
+        specifier: file:pandora/pandora-common
+        version: file:pandora/pandora-common
+      rimraf:
+        specifier: 5.0.1
+        version: 5.0.1
+      sharp:
+        specifier: 0.32.5
+        version: 0.32.5
+      simple-git:
+        specifier: 3.19.1
+        version: 3.19.1
+      zod:
+        specifier: 3.22.2
+        version: 3.22.2
+    devDependencies:
+      '@types/express':
+        specifier: 4.17.17
+        version: 4.17.17
+      '@types/jest':
+        specifier: 29.5.4
+        version: 29.5.4
+      '@types/lodash':
+        specifier: 4.14.198
+        version: 4.14.198
+      '@types/node':
+        specifier: 18.17.15
+        version: 18.17.15
+      '@types/sharp':
+        specifier: 0.31.1
+        version: 0.31.1
+      '@typescript-eslint/eslint-plugin':
+        specifier: 6.7.0
+        version: 6.7.0(@typescript-eslint/parser@6.7.0)(eslint@8.49.0)(typescript@5.2.2)
+      '@typescript-eslint/parser':
+        specifier: 6.7.0
+        version: 6.7.0(eslint@8.49.0)(typescript@5.2.2)
+      eslint:
+        specifier: 8.49.0
+        version: 8.49.0
+      express:
+        specifier: 4.18.2
+        version: 4.18.2
+      immer:
+        specifier: ^10.0.2
+        version: 10.0.2
+      jest:
+        specifier: 29.7.0
+        version: 29.7.0(@types/node@18.17.15)
+      ts-jest:
+        specifier: 29.1.1
+        version: 29.1.1(@babel/core@7.21.3)(jest@29.7.0)(typescript@5.2.2)
+      ts-mockito:
+        specifier: 2.6.1
+        version: 2.6.1
+      tsc-watch:
+        specifier: 6.0.4
+        version: 6.0.4(typescript@5.2.2)
+      tslib:
+        specifier: 2.6.2
+        version: 2.6.2
+      typescript:
+        specifier: 5.2.2
+        version: 5.2.2
 
 packages:
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  # exclude packages in submodule
+  - '!pandora/**'


### PR DESCRIPTION
This fixes problem of Renovate sometimes failing to run update.
The problem is, that Renovate always runs `install` with `--recursive`, which is normally good, but in our specific case it tries to install things in the submodule too and that breaks it. Fixed by turning the package into a workspace that explicitly excludes the `pandora` submodule.