### PR TITLE
[DEV] Better write config for color normalization script

### DIFF
--- a/src/tools/normalize.ts
+++ b/src/tools/normalize.ts
@@ -111,6 +111,9 @@ async function Run() {
 
 			Normalize(image, maxR, maxG, maxB);
 
+			image.filterType(Jimp.PNG_FILTER_AUTO);
+			image.deflateStrategy(0);
+			image.deflateLevel(9);
 			await image.writeAsync(resultPath);
 			const resultSize = fs.statSync(resultPath).size;
 			logger.info(`\tDone; ${originalSize} -> ${resultSize}`);


### PR DESCRIPTION
Jimp's default settings are focused on speed, this changes the settings to favour best compression (without going for extreme measures like special compression algorithm).