### PR TITLE
[CHANGE] Do not sort backgrounds on emit

### DIFF
--- a/src/tools/roomDatabase.ts
+++ b/src/tools/roomDatabase.ts
@@ -16,7 +16,7 @@ export const RoomDatabase = new class RoomDatabase {
 
 	public export(): IChatroomBackgroundInfo[] {
 		const result = Array.from(this.backgrounds.values());
-		result.sort((a, b) => a.name.localeCompare(b.name));
+		// Do NOT sort the exported backgrounds! Order matters.
 
 		return result;
 	}


### PR DESCRIPTION
This change preserves the order of backgrounds as they are in the definition. The sorting has instead been moved to the client's picker (in the personal room PR).
This change is to support selecting a "default" background for personal room by simply defining it first in the list.