### PR TITLE
[CHANGE] Hoods to hide fantasy ears

### DIFF
--- a/src/assets/blindfolds/full_hood/full_hood.asset.ts
+++ b/src/assets/blindfolds/full_hood/full_hood.asset.ts
@@ -33,6 +33,7 @@ DefineAsset({
 		hides: [
 			'Hair',
 			'Ears',
+			'Fantasy_ears',
 		],
 		covers: [
 			'Ear_item',

--- a/src/assets/blindfolds/half_hood/half_hood.asset.ts
+++ b/src/assets/blindfolds/half_hood/half_hood.asset.ts
@@ -26,6 +26,7 @@ DefineAsset({
 		hides: [
 			'Hair',
 			'Ears',
+			'Fantasy_ears',
 		],
 		covers: [
 			'Ear_item',


### PR DESCRIPTION
With the introduction of cat ears, it was overlooked that they should be hidden by the full and half hood. 
This PR changes this.