### PR TITLE
[CHANGE] Add a module for character facing

### DIFF
--- a/src/assets/room_devices/floor_anchors/floor_anchors.asset.ts
+++ b/src/assets/room_devices/floor_anchors/floor_anchors.asset.ts
@@ -236,12 +236,46 @@ DefineRoomDeviceAsset({
 				},
 			],
 		},
+		position: {
+			type: 'typed',
+			name: 'Ankle cuffs position',
+			staticConfig: { slotName: 'character_slot_middle' },
+			variants: [
+				{
+					id: 'front',
+					name: 'Front-facing',
+					default: true,
+					properties: {
+						slotProperties: {
+							character_slot_middle: {
+								poseLimits: {
+									view: 'front',
+								},
+							},
+						},
+					},
+				},
+				{
+					id: 'back',
+					name: 'Back-facing',
+					properties: {
+						slotProperties: {
+							character_slot_middle: {
+								poseLimits: {
+									view: 'back',
+								},
+							},
+						},
+					},
+				},
+			],
+		},
 		lockCenterChain: {
 			type: 'lockSlot',
 			name: 'Lock for ankle cuff chains',
 			staticConfig: { slotName: 'character_slot_middle' },
 			occupiedProperties: {
-				blockModules: ['center'],
+				blockModules: ['center', 'position'],
 				stateFlags: {
 					requires: {
 						chain_center: 'Locking requires a chain to lock.',


### PR DESCRIPTION
## References

_None_

## About The Pull Request

Adds a new module to the center slot that regulates the facing of bound characters, like on the bondage frame

## Changelog

Authored by: Sandrine

```md
Assets:
- [Floor anchors] Add a module for the facing
```

## Checklist

<!-- Checklist for you to make sure you didn't miss something -->
- [X] The change has been tested locally
- [X] Licensing information and credits were filled in/modified for added/modified assets
- [X] I understand this change is licensed based on [Pandora's Asset Licensing](https://github.com/Project-Pandora-Game/pandora-assets/blob/master/ASSET_LICENSING.md) information
