### PR TITLE
[ADD] closed state to all eyes with blinding effect

### DIFF
--- a/src/assets/body/eyes3/eyes3.asset.ts
+++ b/src/assets/body/eyes3/eyes3.asset.ts
@@ -70,18 +70,13 @@ DefineBodypart({
 				{
 					id: 'closed',
 					name: 'Closed',
-					properties: {
-						stateFlags: {
-							provides: ['eyeClosed'],
-						},
-					},
 				},
 				{
 					id: 'blind',
 					name: 'Closed with blind effect',
 					properties: {
-						stateFlags: {
-							provides: ['eyeClosed'],
+						effects: {
+							blind: 4.99,
 						},
 					},
 				},
@@ -106,12 +101,7 @@ DefineBodypart({
 					name: 'Closed with blind effect',
 					properties: {
 						effects: {
-							blind: 9.98,
-						},
-						stateFlags: {
-							requires: {
-								eyeClosed: 'It is required to change the other eye first.',
-							},
+							blind: 4.99,
 						},
 					},
 				},

--- a/src/assets/body/eyes3/eyes3.asset.ts
+++ b/src/assets/body/eyes3/eyes3.asset.ts
@@ -70,6 +70,20 @@ DefineBodypart({
 				{
 					id: 'closed',
 					name: 'Closed',
+					properties: {
+						stateFlags: {
+							provides: ['eyeClosed'],
+						},
+					},
+				},
+				{
+					id: 'blind',
+					name: 'Closed with blind effect',
+					properties: {
+						stateFlags: {
+							provides: ['eyeClosed'],
+						},
+					},
 				},
 			],
 		},
@@ -86,6 +100,20 @@ DefineBodypart({
 				{
 					id: 'closed',
 					name: 'Closed',
+				},
+				{
+					id: 'blind',
+					name: 'Closed with blind effect',
+					properties: {
+						effects: {
+							blind: 9.98,
+						},
+						stateFlags: {
+							requires: {
+								eyeClosed: 'It is required to change the other eye first.',
+							},
+						},
+					},
 				},
 			],
 		},

--- a/src/assets/body/eyes3/graphics.json
+++ b/src/assets/body/eyes3/graphics.json
@@ -28,6 +28,13 @@
 							],
 							[
 								{
+									"module": "eyeState_l",
+									"operator": "=",
+									"value": "blind"
+								}
+							],
+							[
+								{
 									"blinking": true
 								}
 							]
@@ -83,6 +90,13 @@
 									"module": "eyeState_l",
 									"operator": "=",
 									"value": "closed"
+								}
+							],
+							[
+								{
+									"module": "eyeState_l",
+									"operator": "=",
+									"value": "blind"
 								}
 							],
 							[
@@ -218,6 +232,13 @@
 							],
 							[
 								{
+									"module": "eyeState_l",
+									"operator": "=",
+									"value": "blind"
+								}
+							],
+							[
+								{
 									"blinking": true
 								}
 							]
@@ -273,6 +294,13 @@
 									"module": "eyeState_l",
 									"operator": "=",
 									"value": "closed"
+								}
+							],
+							[
+								{
+									"module": "eyeState_l",
+									"operator": "=",
+									"value": "blind"
 								}
 							],
 							[
@@ -367,6 +395,13 @@
 									"module": "eyeState_l",
 									"operator": "=",
 									"value": "closed"
+								}
+							],
+							[
+								{
+									"module": "eyeState_l",
+									"operator": "=",
+									"value": "blind"
 								}
 							],
 							[

--- a/src/assets/body/eyes4/eyes4.asset.ts
+++ b/src/assets/body/eyes4/eyes4.asset.ts
@@ -70,18 +70,13 @@ DefineBodypart({
 				{
 					id: 'closed',
 					name: 'Closed',
-					properties: {
-						stateFlags: {
-							provides: ['eyeClosed'],
-						},
-					},
 				},
 				{
 					id: 'blind',
 					name: 'Closed with blind effect',
 					properties: {
-						stateFlags: {
-							provides: ['eyeClosed'],
+						effects: {
+							blind: 4.99,
 						},
 					},
 				},
@@ -106,12 +101,7 @@ DefineBodypart({
 					name: 'Closed with blind effect',
 					properties: {
 						effects: {
-							blind: 9.98,
-						},
-						stateFlags: {
-							requires: {
-								eyeClosed: 'It is required to change the other eye first.',
-							},
+							blind: 4.99,
 						},
 					},
 				},

--- a/src/assets/body/eyes4/eyes4.asset.ts
+++ b/src/assets/body/eyes4/eyes4.asset.ts
@@ -70,6 +70,20 @@ DefineBodypart({
 				{
 					id: 'closed',
 					name: 'Closed',
+					properties: {
+						stateFlags: {
+							provides: ['eyeClosed'],
+						},
+					},
+				},
+				{
+					id: 'blind',
+					name: 'Closed with blind effect',
+					properties: {
+						stateFlags: {
+							provides: ['eyeClosed'],
+						},
+					},
 				},
 			],
 		},
@@ -86,6 +100,20 @@ DefineBodypart({
 				{
 					id: 'closed',
 					name: 'Closed',
+				},
+				{
+					id: 'blind',
+					name: 'Closed with blind effect',
+					properties: {
+						effects: {
+							blind: 9.98,
+						},
+						stateFlags: {
+							requires: {
+								eyeClosed: 'It is required to change the other eye first.',
+							},
+						},
+					},
 				},
 			],
 		},

--- a/src/assets/body/eyes4/graphics.json
+++ b/src/assets/body/eyes4/graphics.json
@@ -28,6 +28,13 @@
 							],
 							[
 								{
+									"module": "eyeState_l",
+									"operator": "=",
+									"value": "blind"
+								}
+							],
+							[
+								{
 									"blinking": true
 								}
 							]
@@ -83,6 +90,13 @@
 									"module": "eyeState_l",
 									"operator": "=",
 									"value": "closed"
+								}
+							],
+							[
+								{
+									"module": "eyeState_l",
+									"operator": "=",
+									"value": "blind"
 								}
 							],
 							[
@@ -218,6 +232,13 @@
 							],
 							[
 								{
+									"module": "eyeState_l",
+									"operator": "=",
+									"value": "blind"
+								}
+							],
+							[
+								{
 									"blinking": true
 								}
 							]
@@ -273,6 +294,13 @@
 									"module": "eyeState_l",
 									"operator": "=",
 									"value": "closed"
+								}
+							],
+							[
+								{
+									"module": "eyeState_l",
+									"operator": "=",
+									"value": "blind"
 								}
 							],
 							[
@@ -367,6 +395,13 @@
 									"module": "eyeState_l",
 									"operator": "=",
 									"value": "closed"
+								}
+							],
+							[
+								{
+									"module": "eyeState_l",
+									"operator": "=",
+									"value": "blind"
 								}
 							],
 							[

--- a/src/assets/body/eyes5/eyes5.asset.ts
+++ b/src/assets/body/eyes5/eyes5.asset.ts
@@ -55,18 +55,13 @@ DefineBodypart({
 				{
 					id: 'closed',
 					name: 'Closed',
-					properties: {
-						stateFlags: {
-							provides: ['eyeClosed'],
-						},
-					},
 				},
 				{
 					id: 'blind',
 					name: 'Closed with blind effect',
 					properties: {
-						stateFlags: {
-							provides: ['eyeClosed'],
+						effects: {
+							blind: 4.99,
 						},
 					},
 				},
@@ -95,12 +90,7 @@ DefineBodypart({
 					name: 'Closed with blind effect',
 					properties: {
 						effects: {
-							blind: 9.98,
-						},
-						stateFlags: {
-							requires: {
-								eyeClosed: 'It is required to change the other eye first.',
-							},
+							blind: 4.99,
 						},
 					},
 				},

--- a/src/assets/body/eyes5/eyes5.asset.ts
+++ b/src/assets/body/eyes5/eyes5.asset.ts
@@ -55,6 +55,20 @@ DefineBodypart({
 				{
 					id: 'closed',
 					name: 'Closed',
+					properties: {
+						stateFlags: {
+							provides: ['eyeClosed'],
+						},
+					},
+				},
+				{
+					id: 'blind',
+					name: 'Closed with blind effect',
+					properties: {
+						stateFlags: {
+							provides: ['eyeClosed'],
+						},
+					},
 				},
 			],
 		},
@@ -75,6 +89,20 @@ DefineBodypart({
 				{
 					id: 'closed',
 					name: 'Closed',
+				},
+				{
+					id: 'blind',
+					name: 'Closed with blind effect',
+					properties: {
+						effects: {
+							blind: 9.98,
+						},
+						stateFlags: {
+							requires: {
+								eyeClosed: 'It is required to change the other eye first.',
+							},
+						},
+					},
 				},
 			],
 		},

--- a/src/assets/body/eyes5/graphics.json
+++ b/src/assets/body/eyes5/graphics.json
@@ -548,6 +548,13 @@
 							],
 							[
 								{
+									"module": "eyeState_l",
+									"operator": "=",
+									"value": "blind"
+								}
+							],
+							[
+								{
 									"blinking": true
 								}
 							]
@@ -580,6 +587,13 @@
 									"module": "eyeState_l",
 									"operator": "=",
 									"value": "closed"
+								}
+							],
+							[
+								{
+									"module": "eyeState_l",
+									"operator": "=",
+									"value": "blind"
 								}
 							],
 							[
@@ -650,6 +664,13 @@
 									"module": "eyeState_l",
 									"operator": "=",
 									"value": "closed"
+								}
+							],
+							[
+								{
+									"module": "eyeState_l",
+									"operator": "=",
+									"value": "blind"
 								}
 							]
 						]


### PR DESCRIPTION
## References


_None_

## About The Pull Request

Yes!

## Changelog

Authored by: Claudia

```md
Assets:
- [Eyes3] Added a second closed eye state that also adds a blinding effect for more immersion
- [Eyes4] Added a second closed eye state that also adds a blinding effect for more immersion
- [Eyes5] Added a second closed eye state that also adds a blinding effect for more immersion
```

## Checklist

<!-- Checklist for you to make sure you didn't miss something -->
- [x] The change has been tested locally
- [x] Licensing information and credits were filled in/modified for added/modified assets
- [x] I understand this change is licensed based on [Pandora's Asset Licensing](https://github.com/Project-Pandora-Game/pandora-assets/blob/master/ASSET_LICENSING.md) information
