### PR TITLE
[ADD] New attributes for assets to be later used for filtering

### DIFF
--- a/src/assets/accessories/chain_leash/chain_leash.asset.ts
+++ b/src/assets/accessories/chain_leash/chain_leash.asset.ts
@@ -18,6 +18,7 @@ DefineAsset({
 		provides: [
 			'Restraint',
 			'Accessory',
+			'PetPlay',
 		],
 		requires: [
 			'Collar_front_ring',

--- a/src/assets/accessories/cowbell/cowbell.asset.ts
+++ b/src/assets/accessories/cowbell/cowbell.asset.ts
@@ -14,6 +14,7 @@ DefineAsset({
 	attributes: {
 		provides: [
 			'Accessory',
+			'PetPlay',
 		],
 		requires: [
 			'Collar_front_ring',

--- a/src/assets/arm_restraints/arm_jute_ropes/arm_jute_ropes.asset.ts
+++ b/src/assets/arm_restraints/arm_jute_ropes/arm_jute_ropes.asset.ts
@@ -14,6 +14,7 @@ DefineAsset({
 		provides: [
 			'Restraint',
 			'Restraint_arms',
+			'Shibari',
 		],
 	},
 	modules: {

--- a/src/assets/arm_restraints/bamboo_stick/bamboo_stick.asset.ts
+++ b/src/assets/arm_restraints/bamboo_stick/bamboo_stick.asset.ts
@@ -18,6 +18,7 @@ DefineAsset({
 		provides: [
 			'Restraint',
 			'Restraint_arms',
+			'Shibari',
 		],
 	},
 	poseLimits: {

--- a/src/assets/arm_restraints/inflatable_sleeping_bag/inflatable_sleeping_bag.asset.ts
+++ b/src/assets/arm_restraints/inflatable_sleeping_bag/inflatable_sleeping_bag.asset.ts
@@ -36,6 +36,7 @@ DefineAsset({
 			'Anus_cover',
 			'Vulva_cover',
 			'Breast_cover',
+			'Latex',
 		],
 		covers: [
 			'Clothing_upper',

--- a/src/assets/arm_restraints/paw_mittens/paw_mittens.asset.ts
+++ b/src/assets/arm_restraints/paw_mittens/paw_mittens.asset.ts
@@ -37,6 +37,7 @@ DefineAsset({
 			'Hand_restricting_cover',
 			'Gloves',
 			'Mittens',
+			'PetPlay',
 		],
 		covers: [
 			'Hand_item',

--- a/src/assets/arm_restraints/pet_crawler_armbinders/pet_crawler_armbinders.asset.ts
+++ b/src/assets/arm_restraints/pet_crawler_armbinders/pet_crawler_armbinders.asset.ts
@@ -29,6 +29,7 @@ DefineAsset({
 		provides: [
 			'Restraint',
 			'Restraint_arms',
+			'PetPlay',
 		],
 	},
 	modules: {

--- a/src/assets/arm_restraints/torso_ropes/torso_ropes.asset.ts
+++ b/src/assets/arm_restraints/torso_ropes/torso_ropes.asset.ts
@@ -16,6 +16,7 @@ DefineAsset({
 			'Restraint',
 			'Restraint_arms',
 			'Restraint_torso',
+			'Shibari',
 		],
 	},
 	modules: {

--- a/src/assets/bras/latex_corset/latex_corset.asset.ts
+++ b/src/assets/bras/latex_corset/latex_corset.asset.ts
@@ -25,6 +25,7 @@ DefineAsset({
 			'Restraint_torso',
 			'Underwear',
 			'Underwear_corset',
+			'Latex',
 		],
 	},
 	modules: {

--- a/src/assets/dresses/latex_catsuit/latex_catsuit.asset.ts
+++ b/src/assets/dresses/latex_catsuit/latex_catsuit.asset.ts
@@ -26,6 +26,7 @@ DefineAsset({
 			'Clothing_large',
 			'Restraint',
 			'Restraint_torso',
+			'Latex',
 		],
 	},
 	modules: {

--- a/src/assets/dresses/latex_dress/latex_dress.asset.ts
+++ b/src/assets/dresses/latex_dress/latex_dress.asset.ts
@@ -17,6 +17,7 @@ DefineAsset({
 			'Clothing_upper',
 			'Clothing_lower',
 			'Clothing_large',
+			'Latex',
 		],
 	},
 	modules: {

--- a/src/assets/dresses/latex_swimsuit/latex_swimsuit.asset.ts
+++ b/src/assets/dresses/latex_swimsuit/latex_swimsuit.asset.ts
@@ -26,6 +26,7 @@ DefineAsset({
 			'Restraint_torso',
 			'Anus_cover',
 			'Vulva_cover',
+			'Latex',
 		],
 		hides: [
 			'Penis',

--- a/src/assets/dresses/onesie/onesie.asset.ts
+++ b/src/assets/dresses/onesie/onesie.asset.ts
@@ -30,6 +30,7 @@ DefineAsset({
 			'Clothing_lower',
 			'Clothing_large',
 			'Vulva_cover',
+			'ABLD',
 		],
 		hides: [
 			'Penis',

--- a/src/assets/dresses/suspension_harness/suspension_harness.asset.ts
+++ b/src/assets/dresses/suspension_harness/suspension_harness.asset.ts
@@ -14,6 +14,7 @@ DefineAsset({
 		provides: [
 			'Restraint',
 			'Restraint_torso',
+			'Shibari',
 		],
 	},
 	modules: {

--- a/src/assets/foot_restraints/leg_jute_ropes/leg_jute_ropes.asset.ts
+++ b/src/assets/foot_restraints/leg_jute_ropes/leg_jute_ropes.asset.ts
@@ -15,6 +15,7 @@ DefineAsset({
 		provides: [
 			'Restraint',
 			'Restraint_legs',
+			'Shibari',
 		],
 	},
 	modules: {

--- a/src/assets/foot_restraints/leg_ropes/leg_ropes.asset.ts
+++ b/src/assets/foot_restraints/leg_ropes/leg_ropes.asset.ts
@@ -15,6 +15,7 @@ DefineAsset({
 		provides: [
 			'Restraint',
 			'Restraint_legs',
+			'Shibari',
 		],
 	},
 	modules: {

--- a/src/assets/gags/bamboo_gag/bamboo_gag.asset.ts
+++ b/src/assets/gags/bamboo_gag/bamboo_gag.asset.ts
@@ -22,6 +22,7 @@ DefineAsset({
 			'Mouth_item',
 			'Mouth_insert',
 			'Mouth_cover',
+			'Shibari',
 		],
 		requires: [
 			'Mouth_open_wide',

--- a/src/assets/gags/jute_rope_gag/jute_rope_gag.asset.ts
+++ b/src/assets/gags/jute_rope_gag/jute_rope_gag.asset.ts
@@ -18,6 +18,7 @@ DefineAsset({
 			'Mouth_item',
 			'Mouth_insert',
 			'Mouth_cover',
+			'Shibari',
 		],
 		requires: [
 			'Mouth_open_wide',

--- a/src/assets/gloves/gloves/gloves.asset.ts
+++ b/src/assets/gloves/gloves/gloves.asset.ts
@@ -23,6 +23,8 @@ DefineAsset({
 	attributes: {
 		provides: [
 			'Gloves',
+			'Latex',
+			'PetPlay',
 		],
 	},
 	modules: {

--- a/src/assets/headwear/ears_bunny/ears_bunny.asset.ts
+++ b/src/assets/headwear/ears_bunny/ears_bunny.asset.ts
@@ -23,6 +23,7 @@ DefineAsset({
 			'Clothing',
 			'Fantasy',
 			'Fantasy_ears',
+			'PetPlay',
 		],
 	},
 	ownership: {

--- a/src/assets/headwear/ears_cat/ears_cat.asset.ts
+++ b/src/assets/headwear/ears_cat/ears_cat.asset.ts
@@ -23,6 +23,7 @@ DefineAsset({
 			'Clothing',
 			'Fantasy',
 			'Fantasy_ears',
+			'PetPlay',
 		],
 	},
 	ownership: {

--- a/src/assets/headwear/ears_mouse/ears_mouse.asset.ts
+++ b/src/assets/headwear/ears_mouse/ears_mouse.asset.ts
@@ -23,6 +23,7 @@ DefineAsset({
 			'Clothing',
 			'Fantasy',
 			'Fantasy_ears',
+			'PetPlay',
 		],
 	},
 	ownership: {

--- a/src/assets/headwear/ears_puppy/ears_puppy.asset.ts
+++ b/src/assets/headwear/ears_puppy/ears_puppy.asset.ts
@@ -19,6 +19,7 @@ DefineAsset({
 			'Clothing',
 			'Fantasy',
 			'Fantasy_ears',
+			'PetPlay',
 		],
 	},
 	ownership: {

--- a/src/assets/legwear/latex_socks/latex_socks.asset.ts
+++ b/src/assets/legwear/latex_socks/latex_socks.asset.ts
@@ -19,6 +19,7 @@ DefineAsset({
 		provides: [
 			'Clothing',
 			'Legwear',
+			'Latex',
 		],
 	},
 	ownership: {

--- a/src/assets/panties/crotch_jute_rope/crotch_jute_rope.asset.ts
+++ b/src/assets/panties/crotch_jute_rope/crotch_jute_rope.asset.ts
@@ -13,6 +13,7 @@ DefineAsset({
 			'Restraint',
 			'Restraint_torso',
 			'Chastity',
+			'Shibari',
 		],
 		requires: [
 			'!Penis',

--- a/src/assets/room_devices/large_cage/large_cage.asset.ts
+++ b/src/assets/room_devices/large_cage/large_cage.asset.ts
@@ -12,7 +12,10 @@ DefineRoomDeviceAsset({
 			default: '#ffffff',
 		},
 	},
-	staticAttributes: ['Play_furniture'],
+	staticAttributes: [
+		'Play_furniture',
+		'PetPlay',
+	],
 	preview: 'cage_preview.png',
 	slots: {
 		character_slot_left: {

--- a/src/assets/room_devices/pet_bowl/pet_bowl.asset.ts
+++ b/src/assets/room_devices/pet_bowl/pet_bowl.asset.ts
@@ -11,7 +11,10 @@ DefineRoomDeviceAsset({
 			default: '#FEF9F3',
 		},
 	},
-	staticAttributes: ['Floor'],
+	staticAttributes: [
+		'Floor',
+		'PetPlay',
+	],
 	preview: 'pet_bowl_preview.png',
 	slots: {},
 	modules: {

--- a/src/assets/room_devices/pet_hut/pet_hut.asset.ts
+++ b/src/assets/room_devices/pet_hut/pet_hut.asset.ts
@@ -16,7 +16,10 @@ DefineRoomDeviceAsset({
 		},
 
 	},
-	staticAttributes: ['Furniture'],
+	staticAttributes: [
+		'Furniture',
+		'PetPlay',
+	],
 	preview: 'preview.png',
 	slots: {
 		character_slot_inside: {

--- a/src/assets/room_devices/suspension_bamboo/suspension_bamboo.asset.ts
+++ b/src/assets/room_devices/suspension_bamboo/suspension_bamboo.asset.ts
@@ -16,7 +16,10 @@ DefineRoomDeviceAsset({
 			default: '#D7AC4D',
 		},
 	},
-	staticAttributes: ['Play_furniture'],
+	staticAttributes: [
+		'Play_furniture',
+		'Shibari',
+	],
 	slots: {
 		under_bamboo: {
 			name: 'Under the Bamboo',

--- a/src/assets/toys/bunny_tail_plug/bunny_tail_plug.asset.ts
+++ b/src/assets/toys/bunny_tail_plug/bunny_tail_plug.asset.ts
@@ -18,6 +18,7 @@ DefineAsset({
 			'Anus_insert',
 			'Anus_insert_deep',
 			'Toy',
+			'PetPlay',
 		],
 		requires: [
 			'!Anus_cover',

--- a/src/assets/toys/cat_tail_plug/cat_tail_plug.asset.ts
+++ b/src/assets/toys/cat_tail_plug/cat_tail_plug.asset.ts
@@ -26,6 +26,7 @@ DefineAsset({
 			'Anus_insert',
 			'Anus_insert_deep',
 			'Toy',
+			'PetPlay',
 		],
 		requires: [
 			'!Anus_cover',

--- a/src/assets/toys/puppy_tail_plug/puppy_tail_plug.asset.ts
+++ b/src/assets/toys/puppy_tail_plug/puppy_tail_plug.asset.ts
@@ -18,6 +18,7 @@ DefineAsset({
 			'Anus_insert',
 			'Anus_insert_deep',
 			'Toy',
+			'PetPlay',
 		],
 		requires: [
 			'!Anus_cover',

--- a/src/attributes.ts
+++ b/src/attributes.ts
@@ -682,6 +682,27 @@ const ATTRIBUTES_DEFINITION_BASE = {
 		description: 'A fix point behind the head to which a gag can be secured',
 		useAsAssetPreference: false,
 	},
+	// Attributes for filtering
+	Latex: {
+		name: 'Latex',
+		description: 'An asset consisting of or possibly providing the look of latex',
+		useAsAssetPreference: false,
+	},
+	ABLD: {
+		name: 'ABDL',
+		description: 'An asset connect to age regression plays',
+		useAsAssetPreference: false,
+	},
+	PetPlay: {
+		name: 'Pet play',
+		description: 'An asset used for pet plays',
+		useAsAssetPreference: false,
+	},
+	Shibari: {
+		name: 'Shibari',
+		description: 'An asset closely connected to the ancient art of Shibari',
+		useAsAssetPreference: false,
+	},
 } as const satisfies Record<string, AssetRepoAttributeDefinition>;
 
 //#endregion


### PR DESCRIPTION
## References

_None_

## About The Pull Request

Added attributes for
* Shibari
* ABDL
* Petplay
* Latex

and assigned them to the existing assets, so that these can be used for asset filtering at a later point in time

## Changelog

Authored by: Sandrine


```md
Assets:
New attributes that should be used, when assets are created
```

## Checklist

<!-- Checklist for you to make sure you didn't miss something -->
- [X] The change has been tested locally
- [X] Licensing information and credits were filled in/modified for added/modified assets
- [X] I understand this change is licensed based on [Pandora's Asset Licensing](https://github.com/Project-Pandora-Game/pandora-assets/blob/master/ASSET_LICENSING.md) information
