### PR TITLE
[CHANGE] Interaction type for tail positions

### DIFF
--- a/src/assets/body/tail_cat/tail_cat.asset.ts
+++ b/src/assets/body/tail_cat/tail_cat.asset.ts
@@ -1,3 +1,5 @@
+import { ItemInteractionType } from 'pandora-common';
+
 DefineBodypart({
 	name: 'Cat Tail',
 	bodypart: 'tail',
@@ -51,6 +53,7 @@ DefineBodypart({
 		horizontal: {
 			type: 'typed',
 			name: 'Horizontal Alignment',
+			interactionType: ItemInteractionType.ACCESS_ONLY,
 			variants: [
 				{
 					id: 'left',
@@ -66,6 +69,7 @@ DefineBodypart({
 		vertical: {
 			type: 'typed',
 			name: 'Vertical Alignment',
+			interactionType: ItemInteractionType.ACCESS_ONLY,
 			variants: [
 				{
 					id: 'up',

--- a/src/assets/body/tail_cat/tail_cat.asset.ts
+++ b/src/assets/body/tail_cat/tail_cat.asset.ts
@@ -1,5 +1,3 @@
-import { ItemInteractionType } from 'pandora-common';
-
 DefineBodypart({
 	name: 'Cat Tail',
 	bodypart: 'tail',
@@ -53,7 +51,7 @@ DefineBodypart({
 		horizontal: {
 			type: 'typed',
 			name: 'Horizontal Alignment',
-			interactionType: ItemInteractionType.ACCESS_ONLY,
+			expression: 'Horizontal Tail Direction',
 			variants: [
 				{
 					id: 'left',
@@ -69,7 +67,7 @@ DefineBodypart({
 		vertical: {
 			type: 'typed',
 			name: 'Vertical Alignment',
-			interactionType: ItemInteractionType.ACCESS_ONLY,
+			expression: 'Vertical Tail Direction',
 			variants: [
 				{
 					id: 'up',

--- a/src/assets/body/tail_puppy/tail_puppy.asset.ts
+++ b/src/assets/body/tail_puppy/tail_puppy.asset.ts
@@ -1,3 +1,5 @@
+import { ItemInteractionType } from 'pandora-common';
+
 DefineBodypart({
 	name: 'Puppy Tail',
 	bodypart: 'tail',
@@ -39,6 +41,7 @@ DefineBodypart({
 		horizontal: {
 			type: 'typed',
 			name: 'Horizontal Alignment',
+			interactionType: ItemInteractionType.ACCESS_ONLY,
 			variants: [
 				{
 					id: 'left',
@@ -54,6 +57,7 @@ DefineBodypart({
 		vertical: {
 			type: 'typed',
 			name: 'Vertical Alignment',
+			interactionType: ItemInteractionType.ACCESS_ONLY,
 			variants: [
 				{
 					id: 'up',

--- a/src/assets/body/tail_puppy/tail_puppy.asset.ts
+++ b/src/assets/body/tail_puppy/tail_puppy.asset.ts
@@ -1,5 +1,3 @@
-import { ItemInteractionType } from 'pandora-common';
-
 DefineBodypart({
 	name: 'Puppy Tail',
 	bodypart: 'tail',
@@ -41,7 +39,7 @@ DefineBodypart({
 		horizontal: {
 			type: 'typed',
 			name: 'Horizontal Alignment',
-			interactionType: ItemInteractionType.ACCESS_ONLY,
+			expression: 'Horizontal Tail Direction',
 			variants: [
 				{
 					id: 'left',
@@ -57,7 +55,7 @@ DefineBodypart({
 		vertical: {
 			type: 'typed',
 			name: 'Vertical Alignment',
-			interactionType: ItemInteractionType.ACCESS_ONLY,
+			expression: 'Vertical Tail Direction',
 			variants: [
 				{
 					id: 'up',


### PR DESCRIPTION
## References

_None_

## About The Pull Request

Changed the interaction type for the new body part tails so that their position can be changed even ion rooms that prohibit body changes 

## Changelog

Authored by: Sandrine

```md
Assets:
- [body/cat tail, body/ puppy tail] Changed the tail position to be an expression for quicker access and so that it can be changed even in rooms that block body modifications
```

## Checklist

<!-- Checklist for you to make sure you didn't miss something -->
- [X] The change has been tested locally
- [X] Licensing information and credits were filled in/modified for added/modified assets
- [X] I understand this change is licensed based on [Pandora's Asset Licensing](https://github.com/Project-Pandora-Game/pandora-assets/blob/master/ASSET_LICENSING.md) information
