### PR TITLE
[FIX] Name of front hair 11

### DIFF
--- a/src/assets/body/front_hair11/front_hair11.asset.ts
+++ b/src/assets/body/front_hair11/front_hair11.asset.ts
@@ -2,7 +2,7 @@ import { CreateHairColor } from '../../../helpers/hair_base.js';
 const { colorization, modules } = CreateHairColor(true);
 
 DefineBodypart({
-	name: 'Front hair 10',
+	name: 'Front hair 11',
 	bodypart: 'fronthair',
 	allowRandomizerUsage: true,
 	graphics: 'graphics.json',


### PR DESCRIPTION
## References

_None_

## About The Pull Request

Fixed Front hair 11 being named Front hair 10

## Changelog

Authored by: Sandrine

```md
Assets:
- [Front Hair 11] Corrected name
```

## Checklist

<!-- Checklist for you to make sure you didn't miss something -->
- [X] The change has been tested locally
- [X] Licensing information and credits were filled in/modified for added/modified assets
- [X] I understand this change is licensed based on [Pandora's Asset Licensing](https://github.com/Project-Pandora-Game/pandora-assets/blob/master/ASSET_LICENSING.md) information
