### PR TITLE
[CHANGE] custom chat messages in all items now support custom names

### DIFF
--- a/src/assets/accessories/bondage_belt/bondage_belt.asset.ts
+++ b/src/assets/accessories/bondage_belt/bondage_belt.asset.ts
@@ -40,8 +40,8 @@ DefineAsset({
 		},
 	},
 	chat: {
-		actionAdd: 'SOURCE_CHARACTER fastened a bondage belt around TARGET_CHARACTER_DYNAMIC_POSSESSIVE waist.',
-		actionRemove: 'SOURCE_CHARACTER loosened and slipped off the bondage belt from TARGET_CHARACTER_DYNAMIC_POSSESSIVE waist.',
+		actionAdd: 'SOURCE_CHARACTER fastened ITEM_ASSET_NAME around TARGET_CHARACTER_DYNAMIC_POSSESSIVE waist.',
+		actionRemove: 'SOURCE_CHARACTER loosened and slipped off ITEM_ASSET_NAME from TARGET_CHARACTER_DYNAMIC_POSSESSIVE waist.',
 	},
 	ownership: {
 		responsibleContributor: 'Sandrine <118102950+SandrinePDR@users.noreply.github.com>',

--- a/src/assets/accessories/chain_leash/chain_leash.asset.ts
+++ b/src/assets/accessories/chain_leash/chain_leash.asset.ts
@@ -60,8 +60,8 @@ DefineAsset({
 		},
 	},
 	chat: {
-		actionAdd: 'SOURCE_CHARACTER hooked and closed a Chain Leash onto TARGET_CHARACTER_DYNAMIC_POSSESSIVE neck ring.',
-		actionRemove: 'SOURCE_CHARACTER opened and then removed the Chain Leash from TARGET_CHARACTER_DYNAMIC_POSSESSIVE neck ring.',
+		actionAdd: 'SOURCE_CHARACTER hooked and closed ITEM_ASSET_NAME onto TARGET_CHARACTER_DYNAMIC_POSSESSIVE ring.',
+		actionRemove: 'SOURCE_CHARACTER opened and then removed ITEM_ASSET_NAME from TARGET_CHARACTER_DYNAMIC_POSSESSIVE ring.',
 	},
 	ownership: {
 		responsibleContributor: 'ClaudiaMia <99583892+ClaudiaMia@users.noreply.github.com>',
@@ -79,7 +79,7 @@ DefineAsset({
 				source: 'Self-Made',
 				part: 'New positions',
 				copyrightHolder: 'ClaudiaMia',
-				editedBy: 'Taja, Sandrione',
+				editedBy: 'Taja, Sandrine',
 				license: 'Pandora-Use-Only-v1-or-later',
 			},
 		],

--- a/src/assets/accessories/cowbell/cowbell.asset.ts
+++ b/src/assets/accessories/cowbell/cowbell.asset.ts
@@ -29,8 +29,8 @@ DefineAsset({
 		},
 	},
 	chat: {
-		actionAdd: 'SOURCE_CHARACTER attached a cowbell onto TARGET_CHARACTER_DYNAMIC_POSSESSIVE neck ring.',
-		actionRemove: 'SOURCE_CHARACTER removed the cowbell from TARGET_CHARACTER_DYNAMIC_POSSESSIVE neck ring.',
+		actionAdd: 'SOURCE_CHARACTER attached ITEM_ASSET_NAME onto TARGET_CHARACTER_DYNAMIC_POSSESSIVE neck ring.',
+		actionRemove: 'SOURCE_CHARACTER removed ITEM_ASSET_NAME from TARGET_CHARACTER_DYNAMIC_POSSESSIVE neck ring.',
 	},
 	ownership: {
 		responsibleContributor: 'Sandrine <118102950+SandrinePDR@users.noreply.github.com>',

--- a/src/assets/accessories/tray/tray.asset.ts
+++ b/src/assets/accessories/tray/tray.asset.ts
@@ -62,7 +62,7 @@ DefineAsset({
 	},
 	chat: {
 		actionAdd: 'SOURCE_CHARACTER placed ITEM_ASSET_NAME over TARGET_CHARACTER_DYNAMIC_POSSESSIVE neck.',
-		actionRemove: 'SOURCE_CHARACTER removed the tray from TARGET_CHARACTER_DYNAMIC_POSSESSIVE body.',
+		actionRemove: 'SOURCE_CHARACTER removed ITEM_ASSET_NAME from TARGET_CHARACTER_DYNAMIC_POSSESSIVE body.',
 	},
 	ownership: {
 		responsibleContributor: 'Sandrine <118102950+SandrinePDR@users.noreply.github.com>',

--- a/src/assets/accessories/tray/tray.asset.ts
+++ b/src/assets/accessories/tray/tray.asset.ts
@@ -61,7 +61,7 @@ DefineAsset({
 		},
 	},
 	chat: {
-		actionAdd: 'SOURCE_CHARACTER placed a serving tray over TARGET_CHARACTER_DYNAMIC_POSSESSIVE neck.',
+		actionAdd: 'SOURCE_CHARACTER placed ITEM_ASSET_NAME over TARGET_CHARACTER_DYNAMIC_POSSESSIVE neck.',
 		actionRemove: 'SOURCE_CHARACTER removed the tray from TARGET_CHARACTER_DYNAMIC_POSSESSIVE body.',
 	},
 	ownership: {

--- a/src/assets/arm_restraints/arm_jute_ropes/arm_jute_ropes.asset.ts
+++ b/src/assets/arm_restraints/arm_jute_ropes/arm_jute_ropes.asset.ts
@@ -340,8 +340,8 @@ DefineAsset({
 		blockHands: true,
 	},
 	chat: {
-		actionAdd: 'SOURCE_CHARACTER tied Torso Jute Ropes around TARGET_CHARACTER_DYNAMIC_POSSESSIVE body.',
-		actionRemove: 'SOURCE_CHARACTER removed the Torso Jute Ropes from TARGET_CHARACTER_DYNAMIC_POSSESSIVE body.',
+		actionAdd: 'SOURCE_CHARACTER tied ITEM_ASSET_NAME around TARGET_CHARACTER_DYNAMIC_POSSESSIVE body.',
+		actionRemove: 'SOURCE_CHARACTER removed ITEM_ASSET_NAME from TARGET_CHARACTER_DYNAMIC_POSSESSIVE body.',
 	},
 	ownership: {
 		responsibleContributor: 'Shikifet <shikifet@gmail.com>',

--- a/src/assets/arm_restraints/armbinder/armbinder.asset.ts
+++ b/src/assets/arm_restraints/armbinder/armbinder.asset.ts
@@ -96,8 +96,8 @@ DefineAsset({
 	},
 	blockSelfAddRemove: true,
 	chat: {
-		actionAdd: 'SOURCE_CHARACTER slipped an armbinder over TARGET_CHARACTER_DYNAMIC_POSSESSIVE arms, lacing it tightly.',
-		actionRemove: 'SOURCE_CHARACTER loosened and then slipped off the armbinder from TARGET_CHARACTER_DYNAMIC_POSSESSIVE arms.',
+		actionAdd: 'SOURCE_CHARACTER slipped ITEM_ASSET_NAME over TARGET_CHARACTER_DYNAMIC_POSSESSIVE arms, lacing it tightly.',
+		actionRemove: 'SOURCE_CHARACTER loosened and then slipped off ITEM_ASSET_NAME from TARGET_CHARACTER_DYNAMIC_POSSESSIVE arms.',
 	},
 	ownership: {
 		responsibleContributor: 'ClaudiaMia <99583892+ClaudiaMia@users.noreply.github.com>',

--- a/src/assets/arm_restraints/bamboo_stick/bamboo_stick.asset.ts
+++ b/src/assets/arm_restraints/bamboo_stick/bamboo_stick.asset.ts
@@ -223,8 +223,8 @@ DefineAsset({
 		},
 	},
 	chat: {
-		actionAdd: 'SOURCE_CHARACTER tied a bamboo stick between TARGET_CHARACTER_DYNAMIC_POSSESSIVE body and arms.',
-		actionRemove: 'SOURCE_CHARACTER removed the bamboo stick from TARGET_CHARACTER_DYNAMIC_POSSESSIVE body.',
+		actionAdd: 'SOURCE_CHARACTER tied ITEM_ASSET_NAME between TARGET_CHARACTER_DYNAMIC_POSSESSIVE body and arms.',
+		actionRemove: 'SOURCE_CHARACTER removed ITEM_ASSET_NAME from TARGET_CHARACTER_DYNAMIC_POSSESSIVE body.',
 	},
 	ownership: {
 		responsibleContributor: 'Shikifet <shikifet@gmail.com>',

--- a/src/assets/arm_restraints/canvas_straitjacket/canvas_straitjacket.asset.ts
+++ b/src/assets/arm_restraints/canvas_straitjacket/canvas_straitjacket.asset.ts
@@ -96,8 +96,8 @@ DefineAsset({
 		},
 	},
 	chat: {
-		actionAdd: 'SOURCE_CHARACTER pushed TARGET_CHARACTER_DYNAMIC_POSSESSIVE arms into rough canvas sleeves and tightly pulled them to TARGET_CHARACTER_DYNAMIC_POSSESSIVE back.',
-		actionRemove: 'SOURCE_CHARACTER loosened and then slipped off the canvas jacket from TARGET_CHARACTER_DYNAMIC_POSSESSIVE arms.',
+		actionAdd: 'SOURCE_CHARACTER pushed TARGET_CHARACTER_DYNAMIC_POSSESSIVE arms into the sleeves of the item ITEM_ASSET_NAME and tightly pulled them to TARGET_CHARACTER_DYNAMIC_POSSESSIVE back.',
+		actionRemove: 'SOURCE_CHARACTER loosened and then slipped off ITEM_ASSET_NAME from TARGET_CHARACTER_DYNAMIC_POSSESSIVE arms.',
 	},
 	ownership: {
 		responsibleContributor: 'Sandrine <118102950+SandrinePDR@users.noreply.github.com>',

--- a/src/assets/arm_restraints/leather_wrist_cuffs/leather_wrist_cuffs.asset.ts
+++ b/src/assets/arm_restraints/leather_wrist_cuffs/leather_wrist_cuffs.asset.ts
@@ -173,8 +173,8 @@ DefineAsset({
 		},
 	},
 	chat: {
-		actionAdd: 'SOURCE_CHARACTER fastened the leather cuffs around TARGET_CHARACTER_DYNAMIC_POSSESSIVE wrists.',
-		actionRemove: 'SOURCE_CHARACTER loosened and slipped off the leather cuffs from TARGET_CHARACTER_DYNAMIC_POSSESSIVE wrists.',
+		actionAdd: 'SOURCE_CHARACTER fastened ITEM_ASSET_NAME around TARGET_CHARACTER_DYNAMIC_POSSESSIVE wrists.',
+		actionRemove: 'SOURCE_CHARACTER loosened and slipped off ITEM_ASSET_NAME from TARGET_CHARACTER_DYNAMIC_POSSESSIVE wrists.',
 	},
 	ownership: {
 		responsibleContributor: 'ClaudiaMia <99583892+ClaudiaMia@users.noreply.github.com>',

--- a/src/assets/arm_restraints/mittens/mittens.asset.ts
+++ b/src/assets/arm_restraints/mittens/mittens.asset.ts
@@ -57,8 +57,8 @@ DefineAsset({
 		blockHands: true,
 	},
 	chat: {
-		actionAdd: 'SOURCE_CHARACTER slipped mittens over TARGET_CHARACTER_DYNAMIC_POSSESSIVE hands and tightens them.',
-		actionRemove: 'SOURCE_CHARACTER loosened and then slipped off the mittens from TARGET_CHARACTER_DYNAMIC_POSSESSIVE hands.',
+		actionAdd: 'SOURCE_CHARACTER slipped ITEM_ASSET_NAME over TARGET_CHARACTER_DYNAMIC_POSSESSIVE hands and tightens them.',
+		actionRemove: 'SOURCE_CHARACTER loosened and then slipped off ITEM_ASSET_NAME from TARGET_CHARACTER_DYNAMIC_POSSESSIVE hands.',
 	},
 	ownership: {
 		responsibleContributor: 'ClaudiaMia <99583892+ClaudiaMia@users.noreply.github.com>',

--- a/src/assets/arm_restraints/paw_mittens/paw_mittens.asset.ts
+++ b/src/assets/arm_restraints/paw_mittens/paw_mittens.asset.ts
@@ -61,8 +61,8 @@ DefineAsset({
 		blockHands: true,
 	},
 	chat: {
-		actionAdd: 'SOURCE_CHARACTER slipped paw mittens over TARGET_CHARACTER_DYNAMIC_POSSESSIVE hands and tightens them.',
-		actionRemove: 'SOURCE_CHARACTER loosened and then slipped off the paw mittens from TARGET_CHARACTER_DYNAMIC_POSSESSIVE hands.',
+		actionAdd: 'SOURCE_CHARACTER slipped ITEM_ASSET_NAME over TARGET_CHARACTER_DYNAMIC_POSSESSIVE hands and tightens them.',
+		actionRemove: 'SOURCE_CHARACTER loosened and then slipped off ITEM_ASSET_NAME from TARGET_CHARACTER_DYNAMIC_POSSESSIVE hands.',
 	},
 	ownership: {
 		responsibleContributor: 'ClaudiaMia <99583892+ClaudiaMia@users.noreply.github.com>',

--- a/src/assets/arm_restraints/pet_crawler_armbinders/pet_crawler_armbinders.asset.ts
+++ b/src/assets/arm_restraints/pet_crawler_armbinders/pet_crawler_armbinders.asset.ts
@@ -112,8 +112,8 @@ DefineAsset({
 		blockHands: true,
 	},
 	chat: {
-		actionAdd: 'SOURCE_CHARACTER slipped a pet crawler armbinder over each of TARGET_CHARACTER_DYNAMIC_POSSESSIVE arms and tightened them into pet leg position.',
-		actionRemove: 'SOURCE_CHARACTER loosened and then slipped off the pet crawler armbinders from TARGET_CHARACTER_DYNAMIC_POSSESSIVE arms.',
+		actionAdd: 'SOURCE_CHARACTER slipped ITEM_ASSET_NAME over each of TARGET_CHARACTER_DYNAMIC_POSSESSIVE arms and tightened them into pet leg position.',
+		actionRemove: 'SOURCE_CHARACTER loosened and then slipped off ITEM_ASSET_NAME from TARGET_CHARACTER_DYNAMIC_POSSESSIVE arms.',
 	},
 	ownership: {
 		responsibleContributor: 'ClaudiaMia <99583892+ClaudiaMia@users.noreply.github.com>',

--- a/src/assets/arm_restraints/steel_spheres/steel_spheres.asset.ts
+++ b/src/assets/arm_restraints/steel_spheres/steel_spheres.asset.ts
@@ -51,8 +51,8 @@ DefineAsset({
 		blockHands: true,
 	},
 	chat: {
-		actionAdd: 'SOURCE_CHARACTER encases TARGET_CHARACTER_DYNAMIC_POSSESSIVE hands with shiny steel spheres.',
-		actionRemove: 'SOURCE_CHARACTER unscrews and then removes the spheres from TARGET_CHARACTER_DYNAMIC_POSSESSIVE hands.',
+		actionAdd: 'SOURCE_CHARACTER encases TARGET_CHARACTER_DYNAMIC_POSSESSIVE hands with ITEM_ASSET_NAME.',
+		actionRemove: 'SOURCE_CHARACTER unscrews and then removes ITEM_ASSET_NAME from TARGET_CHARACTER_DYNAMIC_POSSESSIVE hands.',
 	},
 	ownership: {
 		responsibleContributor: 'Sandrine <118102950+SandrinePDR@users.noreply.github.com>',

--- a/src/assets/arm_restraints/steel_wrist_cuffs/steel_wrist_cuffs.asset.ts
+++ b/src/assets/arm_restraints/steel_wrist_cuffs/steel_wrist_cuffs.asset.ts
@@ -165,8 +165,8 @@ DefineAsset({
 		},
 	},
 	chat: {
-		actionAdd: 'SOURCE_CHARACTER fastened the steel cuffs around TARGET_CHARACTER_DYNAMIC_POSSESSIVE wrists.',
-		actionRemove: 'SOURCE_CHARACTER opened and slipped off the steel cuffs from TARGET_CHARACTER_DYNAMIC_POSSESSIVE wrists.',
+		actionAdd: 'SOURCE_CHARACTER fastened ITEM_ASSET_NAME around TARGET_CHARACTER_DYNAMIC_POSSESSIVE wrists.',
+		actionRemove: 'SOURCE_CHARACTER opened and slipped off ITEM_ASSET_NAME from TARGET_CHARACTER_DYNAMIC_POSSESSIVE wrists.',
 	},
 	ownership: {
 		responsibleContributor: 'Sandrine <118102950+SandrinePDR@users.noreply.github.com>',

--- a/src/assets/arm_restraints/torso_ropes/torso_ropes.asset.ts
+++ b/src/assets/arm_restraints/torso_ropes/torso_ropes.asset.ts
@@ -155,8 +155,8 @@ DefineAsset({
 		},
 	},
 	chat: {
-		actionAdd: 'SOURCE_CHARACTER tied Torso Ropes around TARGET_CHARACTER_DYNAMIC_POSSESSIVE body.',
-		actionRemove: 'SOURCE_CHARACTER removed the Torso Ropes from TARGET_CHARACTER_DYNAMIC_POSSESSIVE body.',
+		actionAdd: 'SOURCE_CHARACTER tied ITEM_ASSET_NAME around TARGET_CHARACTER_DYNAMIC_POSSESSIVE body.',
+		actionRemove: 'SOURCE_CHARACTER removed ITEM_ASSET_NAME from TARGET_CHARACTER_DYNAMIC_POSSESSIVE body.',
 	},
 	ownership: {
 		responsibleContributor: 'ClaudiaMia <99583892+ClaudiaMia@users.noreply.github.com>',

--- a/src/assets/arm_restraints/yoke/yoke.asset.ts
+++ b/src/assets/arm_restraints/yoke/yoke.asset.ts
@@ -134,8 +134,8 @@ DefineAsset({
 		blockHands: true,
 	},
 	chat: {
-		actionAdd: 'SOURCE_CHARACTER fitted and closed a Yoke around TARGET_CHARACTER_DYNAMIC_POSSESSIVE neck and closed the cuffs around both wrists.',
-		actionRemove: 'SOURCE_CHARACTER opened and then removed the Yoke from TARGET_CHARACTER_DYNAMIC_POSSESSIVE neck and wrists.',
+		actionAdd: 'SOURCE_CHARACTER fitted and closed ITEM_ASSET_NAME around TARGET_CHARACTER_DYNAMIC_POSSESSIVE neck and closed the cuffs around both wrists.',
+		actionRemove: 'SOURCE_CHARACTER opened and then removed ITEM_ASSET_NAME from TARGET_CHARACTER_DYNAMIC_POSSESSIVE neck and wrists.',
 	},
 	ownership: {
 		responsibleContributor: 'ClaudiaMia <99583892+ClaudiaMia@users.noreply.github.com>',

--- a/src/assets/blindfolds/cloth_blindfold/cloth_blindfold.asset.ts
+++ b/src/assets/blindfolds/cloth_blindfold/cloth_blindfold.asset.ts
@@ -20,8 +20,8 @@ DefineAsset({
 		blind: 7,
 	},
 	chat: {
-		actionAdd: 'SOURCE_CHARACTER wrapped a layer of cloth around TARGET_CHARACTER_DYNAMIC_POSSESSIVE head, covering the eyes.',
-		actionRemove: 'SOURCE_CHARACTER unwrapped the cloth blindfold from around TARGET_CHARACTER_DYNAMIC_POSSESSIVE head.',
+		actionAdd: 'SOURCE_CHARACTER wrapped ITEM_ASSET_NAME around TARGET_CHARACTER_DYNAMIC_POSSESSIVE head, covering the eyes.',
+		actionRemove: 'SOURCE_CHARACTER unwrapped ITEM_ASSET_NAME from around TARGET_CHARACTER_DYNAMIC_POSSESSIVE head.',
 	},
 	ownership: {
 		responsibleContributor: 'ClaudiaMia <99583892+ClaudiaMia@users.noreply.github.com>',

--- a/src/assets/blindfolds/full_hood/full_hood.asset.ts
+++ b/src/assets/blindfolds/full_hood/full_hood.asset.ts
@@ -148,8 +148,8 @@ DefineAsset({
 		},
 	},
 	chat: {
-		actionAdd: 'SOURCE_CHARACTER pulled a Full Hood over TARGET_CHARACTER_DYNAMIC_POSSESSIVE head, covering the head.',
-		actionRemove: 'SOURCE_CHARACTER removed the Full Hood from TARGET_CHARACTER_DYNAMIC_POSSESSIVE head.',
+		actionAdd: 'SOURCE_CHARACTER pulled ITEM_ASSET_NAME over TARGET_CHARACTER_DYNAMIC_POSSESSIVE head, covering the head.',
+		actionRemove: 'SOURCE_CHARACTER removed ITEM_ASSET_NAME from TARGET_CHARACTER_DYNAMIC_POSSESSIVE head.',
 	},
 	ownership: {
 		responsibleContributor: 'ClaudiaMia <99583892+ClaudiaMia@users.noreply.github.com>',

--- a/src/assets/blindfolds/half_hood/half_hood.asset.ts
+++ b/src/assets/blindfolds/half_hood/half_hood.asset.ts
@@ -46,8 +46,8 @@ DefineAsset({
 		},
 	},
 	chat: {
-		actionAdd: 'SOURCE_CHARACTER pulled a Half Hood over TARGET_CHARACTER_DYNAMIC_POSSESSIVE head, covering the head.',
-		actionRemove: 'SOURCE_CHARACTER removed the Half Hood from TARGET_CHARACTER_DYNAMIC_POSSESSIVE head.',
+		actionAdd: 'SOURCE_CHARACTER pulled ITEM_ASSET_NAME over TARGET_CHARACTER_DYNAMIC_POSSESSIVE head, covering the head.',
+		actionRemove: 'SOURCE_CHARACTER removed ITEM_ASSET_NAME from TARGET_CHARACTER_DYNAMIC_POSSESSIVE head.',
 	},
 	ownership: {
 		responsibleContributor: 'ClaudiaMia <99583892+ClaudiaMia@users.noreply.github.com>',

--- a/src/assets/blindfolds/padded_blindfold/padded_blindfold.asset.ts
+++ b/src/assets/blindfolds/padded_blindfold/padded_blindfold.asset.ts
@@ -58,8 +58,8 @@ DefineAsset({
 		},
 	},
 	chat: {
-		actionAdd: 'SOURCE_CHARACTER strapped a Padded Blindfold around TARGET_CHARACTER_DYNAMIC_POSSESSIVE head, covering the eyes.',
-		actionRemove: 'SOURCE_CHARACTER removed the Padded Blindfold from TARGET_CHARACTER_DYNAMIC_POSSESSIVE head.',
+		actionAdd: 'SOURCE_CHARACTER strapped ITEM_ASSET_NAME around TARGET_CHARACTER_DYNAMIC_POSSESSIVE head, covering the eyes.',
+		actionRemove: 'SOURCE_CHARACTER removed ITEM_ASSET_NAME from TARGET_CHARACTER_DYNAMIC_POSSESSIVE head.',
 	},
 	ownership: {
 		responsibleContributor: 'ClaudiaMia <99583892+ClaudiaMia@users.noreply.github.com>',

--- a/src/assets/blindfolds/steel_sphere/steel_sphere.asset.ts
+++ b/src/assets/blindfolds/steel_sphere/steel_sphere.asset.ts
@@ -92,8 +92,8 @@ DefineAsset({
 		},
 	},
 	chat: {
-		actionAdd: 'SOURCE_CHARACTER closes a Steel Sphere around TARGET_CHARACTER_DYNAMIC_POSSESSIVE head, covering it completely.',
-		actionRemove: 'SOURCE_CHARACTER unscrews the Steel Sphere from TARGET_CHARACTER_DYNAMIC_POSSESSIVE head.',
+		actionAdd: 'SOURCE_CHARACTER closes ITEM_ASSET_NAME around TARGET_CHARACTER_DYNAMIC_POSSESSIVE head, covering it completely.',
+		actionRemove: 'SOURCE_CHARACTER removes ITEM_ASSET_NAME from TARGET_CHARACTER_DYNAMIC_POSSESSIVE head.',
 	},
 	ownership: {
 		responsibleContributor: 'Sandrine <118102950+SandrinePDR@users.noreply.github.com>',

--- a/src/assets/collars/cloth_collar/cloth_collar.asset.ts
+++ b/src/assets/collars/cloth_collar/cloth_collar.asset.ts
@@ -39,8 +39,8 @@ DefineAsset({
 		},
 	},
 	chat: {
-		actionAdd: 'SOURCE_CHARACTER fitted and closed a Cloth Collar around TARGET_CHARACTER_DYNAMIC_POSSESSIVE neck.',
-		actionRemove: 'SOURCE_CHARACTER opened and then removed the Cloth Collar from TARGET_CHARACTER_DYNAMIC_POSSESSIVE neck.',
+		actionAdd: 'SOURCE_CHARACTER fitted and closed ITEM_ASSET_NAME around TARGET_CHARACTER_DYNAMIC_POSSESSIVE neck.',
+		actionRemove: 'SOURCE_CHARACTER opened and then removed ITEM_ASSET_NAME from TARGET_CHARACTER_DYNAMIC_POSSESSIVE neck.',
 	},
 	ownership: {
 		responsibleContributor: 'ClaudiaMia <99583892+ClaudiaMia@users.noreply.github.com>',

--- a/src/assets/collars/heart_choker/heart_choker.asset.ts
+++ b/src/assets/collars/heart_choker/heart_choker.asset.ts
@@ -37,8 +37,8 @@ DefineAsset({
 		},
 	},
 	chat: {
-		actionAdd: 'SOURCE_CHARACTER fitted and closed a Heart Choker around TARGET_CHARACTER_DYNAMIC_POSSESSIVE neck.',
-		actionRemove: 'SOURCE_CHARACTER opened and then removed the Heart Choker from TARGET_CHARACTER_DYNAMIC_POSSESSIVE neck.',
+		actionAdd: 'SOURCE_CHARACTER fitted and closed ITEM_ASSET_NAME around TARGET_CHARACTER_DYNAMIC_POSSESSIVE neck.',
+		actionRemove: 'SOURCE_CHARACTER opened and then removed ITEM_ASSET_NAME from TARGET_CHARACTER_DYNAMIC_POSSESSIVE neck.',
 	},
 	ownership: {
 		responsibleContributor: 'ClaudiaMia <99583892+ClaudiaMia@users.noreply.github.com>',

--- a/src/assets/collars/leather_choker/leather_choker.asset.ts
+++ b/src/assets/collars/leather_choker/leather_choker.asset.ts
@@ -58,8 +58,8 @@ DefineAsset({
 		},
 	},
 	chat: {
-		actionAdd: 'SOURCE_CHARACTER fitted and closed a Leather Choker around TARGET_CHARACTER_DYNAMIC_POSSESSIVE neck.',
-		actionRemove: 'SOURCE_CHARACTER opened and then removed the Leather Choker from TARGET_CHARACTER_DYNAMIC_POSSESSIVE neck.',
+		actionAdd: 'SOURCE_CHARACTER fitted and closed ITEM_ASSET_NAME around TARGET_CHARACTER_DYNAMIC_POSSESSIVE neck.',
+		actionRemove: 'SOURCE_CHARACTER opened and then removed ITEM_ASSET_NAME from TARGET_CHARACTER_DYNAMIC_POSSESSIVE neck.',
 	},
 	ownership: {
 		responsibleContributor: 'ClaudiaMia <99583892+ClaudiaMia@users.noreply.github.com>',

--- a/src/assets/collars/metal_collar/metal_collar.asset.ts
+++ b/src/assets/collars/metal_collar/metal_collar.asset.ts
@@ -71,8 +71,8 @@ DefineAsset({
 		},
 	},
 	chat: {
-		actionAdd: 'SOURCE_CHARACTER fitted and closed a Metal Collar around TARGET_CHARACTER_DYNAMIC_POSSESSIVE neck.',
-		actionRemove: 'SOURCE_CHARACTER opened and then removed the Metal Collar from TARGET_CHARACTER_DYNAMIC_POSSESSIVE neck.',
+		actionAdd: 'SOURCE_CHARACTER fitted and closed ITEM_ASSET_NAME around TARGET_CHARACTER_DYNAMIC_POSSESSIVE neck.',
+		actionRemove: 'SOURCE_CHARACTER opened and then removed ITEM_ASSET_NAME from TARGET_CHARACTER_DYNAMIC_POSSESSIVE neck.',
 	},
 	ownership: {
 		responsibleContributor: 'ClaudiaMia <99583892+ClaudiaMia@users.noreply.github.com>',

--- a/src/assets/collars/posture_collar/posture_collar.asset.ts
+++ b/src/assets/collars/posture_collar/posture_collar.asset.ts
@@ -113,8 +113,8 @@ DefineAsset({
 		},
 	},
 	chat: {
-		actionAdd: 'SOURCE_CHARACTER fitted a Posture Collar around TARGET_CHARACTER_DYNAMIC_POSSESSIVE neck.',
-		actionRemove: 'SOURCE_CHARACTER opened and then removed the Posture Collar from TARGET_CHARACTER_DYNAMIC_POSSESSIVE neck.',
+		actionAdd: 'SOURCE_CHARACTER fitted ITEM_ASSET_NAME around TARGET_CHARACTER_DYNAMIC_POSSESSIVE neck.',
+		actionRemove: 'SOURCE_CHARACTER opened and then removed ITEM_ASSET_NAME from TARGET_CHARACTER_DYNAMIC_POSSESSIVE neck.',
 	},
 	ownership: {
 		responsibleContributor: 'ClaudiaMia <99583892+ClaudiaMia@users.noreply.github.com>',

--- a/src/assets/dresses/suspension_harness/suspension_harness.asset.ts
+++ b/src/assets/dresses/suspension_harness/suspension_harness.asset.ts
@@ -104,8 +104,8 @@ DefineAsset({
 		},
 	},
 	chat: {
-		actionAdd: 'SOURCE_CHARACTER tied a Suspension Harness around TARGET_CHARACTER_DYNAMIC_POSSESSIVE body.',
-		actionRemove: 'SOURCE_CHARACTER removed the Suspension Harness from TARGET_CHARACTER_DYNAMIC_POSSESSIVE body.',
+		actionAdd: 'SOURCE_CHARACTER tied ITEM_ASSET_NAME around TARGET_CHARACTER_DYNAMIC_POSSESSIVE body.',
+		actionRemove: 'SOURCE_CHARACTER removed ITEM_ASSET_NAME from TARGET_CHARACTER_DYNAMIC_POSSESSIVE body.',
 	},
 	ownership: {
 		responsibleContributor: 'Shikifet <shikifet@gmail.com>',

--- a/src/assets/foot_restraints/duct_tape/duct_tape.asset.ts
+++ b/src/assets/foot_restraints/duct_tape/duct_tape.asset.ts
@@ -155,8 +155,8 @@ DefineAsset({
 		},
 	},
 	chat: {
-		actionAdd: 'SOURCE_CHARACTER wraps duct tape around TARGET_CHARACTER_DYNAMIC_POSSESSIVE legs.',
-		actionRemove: 'SOURCE_CHARACTER pulls the duct tape from TARGET_CHARACTER_DYNAMIC_POSSESSIVE legs.',
+		actionAdd: 'SOURCE_CHARACTER wraps ITEM_ASSET_NAME around TARGET_CHARACTER_DYNAMIC_POSSESSIVE legs.',
+		actionRemove: 'SOURCE_CHARACTER pulls ITEM_ASSET_NAME from TARGET_CHARACTER_DYNAMIC_POSSESSIVE legs.',
 	},
 	ownership: {
 		responsibleContributor: 'Sandrine <118102950+SandrinePDR@users.noreply.github.com>',

--- a/src/assets/foot_restraints/leather_ankle_cuffs/leather_ankle_cuffs.asset.ts
+++ b/src/assets/foot_restraints/leather_ankle_cuffs/leather_ankle_cuffs.asset.ts
@@ -228,8 +228,8 @@ DefineAsset({
 		},
 	},
 	chat: {
-		actionAdd: 'SOURCE_CHARACTER fastened the leather cuffs around TARGET_CHARACTER_DYNAMIC_POSSESSIVE ankles.',
-		actionRemove: 'SOURCE_CHARACTER loosened and slipped off the leather cuffs from TARGET_CHARACTER_DYNAMIC_POSSESSIVE ankles.',
+		actionAdd: 'SOURCE_CHARACTER fastened ITEM_ASSET_NAME around TARGET_CHARACTER_DYNAMIC_POSSESSIVE ankles.',
+		actionRemove: 'SOURCE_CHARACTER loosened and slipped off ITEM_ASSET_NAME from TARGET_CHARACTER_DYNAMIC_POSSESSIVE ankles.',
 	},
 	ownership: {
 		responsibleContributor: 'ClaudiaMia <99583892+ClaudiaMia@users.noreply.github.com>',

--- a/src/assets/foot_restraints/leather_thigh_cuffs/leather_thigh_cuffs.asset.ts
+++ b/src/assets/foot_restraints/leather_thigh_cuffs/leather_thigh_cuffs.asset.ts
@@ -135,8 +135,8 @@ DefineAsset({
 		},
 	},
 	chat: {
-		actionAdd: 'SOURCE_CHARACTER fastened the leather cuffs around TARGET_CHARACTER_DYNAMIC_POSSESSIVE thighs.',
-		actionRemove: 'SOURCE_CHARACTER loosened and slipped off the leather cuffs from TARGET_CHARACTER_DYNAMIC_POSSESSIVE thighs.',
+		actionAdd: 'SOURCE_CHARACTER fastened ITEM_ASSET_NAME around TARGET_CHARACTER_DYNAMIC_POSSESSIVE thighs.',
+		actionRemove: 'SOURCE_CHARACTER loosened and slipped off ITEM_ASSET_NAME from TARGET_CHARACTER_DYNAMIC_POSSESSIVE thighs.',
 	},
 	ownership: {
 		responsibleContributor: 'Sandrine <118102950+SandrinePDR@users.noreply.github.com>',

--- a/src/assets/foot_restraints/leg_jute_ropes/leg_jute_ropes.asset.ts
+++ b/src/assets/foot_restraints/leg_jute_ropes/leg_jute_ropes.asset.ts
@@ -324,8 +324,8 @@ DefineAsset({
 		},
 	},
 	chat: {
-		actionAdd: 'SOURCE_CHARACTER tied Leg Jute Ropes around TARGET_CHARACTER_DYNAMIC_POSSESSIVE body.',
-		actionRemove: 'SOURCE_CHARACTER removed the Leg Jute Ropes from TARGET_CHARACTER_DYNAMIC_POSSESSIVE body.',
+		actionAdd: 'SOURCE_CHARACTER tied ITEM_ASSET_NAME around TARGET_CHARACTER_DYNAMIC_POSSESSIVE body.',
+		actionRemove: 'SOURCE_CHARACTER removed ITEM_ASSET_NAME from TARGET_CHARACTER_DYNAMIC_POSSESSIVE body.',
 	},
 	ownership: {
 		responsibleContributor: 'Shikifet <shikifet@gmail.com>',

--- a/src/assets/foot_restraints/leg_ropes/leg_ropes.asset.ts
+++ b/src/assets/foot_restraints/leg_ropes/leg_ropes.asset.ts
@@ -84,8 +84,8 @@ DefineAsset({
 		},
 	},
 	chat: {
-		actionAdd: 'SOURCE_CHARACTER tied Leg Ropes around TARGET_CHARACTER_DYNAMIC_POSSESSIVE legs.',
-		actionRemove: 'SOURCE_CHARACTER removed the Leg Ropes from TARGET_CHARACTER_DYNAMIC_POSSESSIVE legs.',
+		actionAdd: 'SOURCE_CHARACTER tied ITEM_ASSET_NAME around TARGET_CHARACTER_DYNAMIC_POSSESSIVE legs.',
+		actionRemove: 'SOURCE_CHARACTER removed ITEM_ASSET_NAME from TARGET_CHARACTER_DYNAMIC_POSSESSIVE legs.',
 	},
 	ownership: {
 		responsibleContributor: 'ClaudiaMia <99583892+ClaudiaMia@users.noreply.github.com>',

--- a/src/assets/foot_restraints/steel_ankle_cuffs/steel_ankle_cuffs.asset.ts
+++ b/src/assets/foot_restraints/steel_ankle_cuffs/steel_ankle_cuffs.asset.ts
@@ -207,8 +207,8 @@ DefineAsset({
 		},
 	},
 	chat: {
-		actionAdd: 'SOURCE_CHARACTER fastened the steel cuffs around TARGET_CHARACTER_DYNAMIC_POSSESSIVE ankles.',
-		actionRemove: 'SOURCE_CHARACTER removed the steel cuffs from TARGET_CHARACTER_DYNAMIC_POSSESSIVE ankles.',
+		actionAdd: 'SOURCE_CHARACTER fastened ITEM_ASSET_NAME around TARGET_CHARACTER_DYNAMIC_POSSESSIVE ankles.',
+		actionRemove: 'SOURCE_CHARACTER removed ITEM_ASSET_NAME from TARGET_CHARACTER_DYNAMIC_POSSESSIVE ankles.',
 	},
 	ownership: {
 		responsibleContributor: 'ClaudiaMia <99583892+ClaudiaMia@users.noreply.github.com>',

--- a/src/assets/gags/ballgag/ballgag.asset.ts
+++ b/src/assets/gags/ballgag/ballgag.asset.ts
@@ -69,8 +69,8 @@ DefineAsset({
 		stimulus: 2,
 	},
 	chat: {
-		actionAdd: 'SOURCE_CHARACTER strapped a Ball Gag tightly between TARGET_CHARACTER_DYNAMIC_POSSESSIVE lips.',
-		actionRemove: 'SOURCE_CHARACTER loosened and then removed the Ball Gag from TARGET_CHARACTER_DYNAMIC_POSSESSIVE mouth.',
+		actionAdd: 'SOURCE_CHARACTER strapped ITEM_ASSET_NAME tightly between TARGET_CHARACTER_DYNAMIC_POSSESSIVE lips.',
+		actionRemove: 'SOURCE_CHARACTER loosened and then removed ITEM_ASSET_NAME from TARGET_CHARACTER_DYNAMIC_POSSESSIVE mouth.',
 	},
 	ownership: {
 		responsibleContributor: 'ClaudiaMia <99583892+ClaudiaMia@users.noreply.github.com>',

--- a/src/assets/gags/bamboo_gag/bamboo_gag.asset.ts
+++ b/src/assets/gags/bamboo_gag/bamboo_gag.asset.ts
@@ -67,8 +67,8 @@ DefineAsset({
 		stimulus: 1,
 	},
 	chat: {
-		actionAdd: 'SOURCE_CHARACTER tied a Bamboo Gag tightly between TARGET_CHARACTER_DYNAMIC_POSSESSIVE teeth.',
-		actionRemove: 'SOURCE_CHARACTER loosened and then removed the Bamboo Gag from TARGET_CHARACTER_DYNAMIC_POSSESSIVE mouth.',
+		actionAdd: 'SOURCE_CHARACTER tied ITEM_ASSET_NAME tightly between TARGET_CHARACTER_DYNAMIC_POSSESSIVE teeth.',
+		actionRemove: 'SOURCE_CHARACTER loosened and then removed ITEM_ASSET_NAME from TARGET_CHARACTER_DYNAMIC_POSSESSIVE mouth.',
 	},
 	ownership: {
 		responsibleContributor: 'Shikifet <shikifet@gmail.com>',

--- a/src/assets/gags/bitgag/bitgag.asset.ts
+++ b/src/assets/gags/bitgag/bitgag.asset.ts
@@ -50,8 +50,8 @@ DefineAsset({
 		stimulus: 1,
 	},
 	chat: {
-		actionAdd: 'SOURCE_CHARACTER strapped a Bit Gag tightly between TARGET_CHARACTER_DYNAMIC_POSSESSIVE teeth.',
-		actionRemove: 'SOURCE_CHARACTER loosened and then removed the Bit Gag from TARGET_CHARACTER_DYNAMIC_POSSESSIVE mouth.',
+		actionAdd: 'SOURCE_CHARACTER strapped ITEM_ASSET_NAME tightly between TARGET_CHARACTER_DYNAMIC_POSSESSIVE teeth.',
+		actionRemove: 'SOURCE_CHARACTER loosened and then removed ITEM_ASSET_NAME from TARGET_CHARACTER_DYNAMIC_POSSESSIVE mouth.',
 	},
 	ownership: {
 		responsibleContributor: 'ClaudiaMia <99583892+ClaudiaMia@users.noreply.github.com>',

--- a/src/assets/gags/chopsticks_gag/chopsticks_gag.asset.ts
+++ b/src/assets/gags/chopsticks_gag/chopsticks_gag.asset.ts
@@ -38,8 +38,8 @@ DefineAsset({
 		stimulus: 3,
 	},
 	chat: {
-		actionAdd: 'SOURCE_CHARACTER tied some Chopsticks around TARGET_CHARACTER_DYNAMIC_POSSESSIVE tongue.',
-		actionRemove: 'SOURCE_CHARACTER removed the Chopsticks from TARGET_CHARACTER_DYNAMIC_POSSESSIVE mouth.',
+		actionAdd: 'SOURCE_CHARACTER tied some ITEM_ASSET_NAME around TARGET_CHARACTER_DYNAMIC_POSSESSIVE tongue.',
+		actionRemove: 'SOURCE_CHARACTER removed ITEM_ASSET_NAME from TARGET_CHARACTER_DYNAMIC_POSSESSIVE mouth.',
 	},
 	ownership: {
 		responsibleContributor: 'Shikifet <shikifet@gmail.com>',

--- a/src/assets/gags/clothgag/clothgag.asset.ts
+++ b/src/assets/gags/clothgag/clothgag.asset.ts
@@ -141,8 +141,8 @@ DefineAsset({
 		},
 	},
 	chat: {
-		actionAdd: 'SOURCE_CHARACTER wrapped a layer of cloth around TARGET_CHARACTER_DYNAMIC_POSSESSIVE mouth.',
-		actionRemove: 'SOURCE_CHARACTER unwrapped the cloth gag from around TARGET_CHARACTER_DYNAMIC_POSSESSIVE mouth.',
+		actionAdd: 'SOURCE_CHARACTER wrapped ITEM_ASSET_NAME around TARGET_CHARACTER_DYNAMIC_POSSESSIVE mouth.',
+		actionRemove: 'SOURCE_CHARACTER unwrapped ITEM_ASSET_NAME from around TARGET_CHARACTER_DYNAMIC_POSSESSIVE mouth.',
 	},
 	ownership: {
 		responsibleContributor: 'ClaudiaMia <99583892+ClaudiaMia@users.noreply.github.com>',

--- a/src/assets/gags/dildogag/dildogag.asset.ts
+++ b/src/assets/gags/dildogag/dildogag.asset.ts
@@ -70,8 +70,8 @@ DefineAsset({
 		stimulus: 6,
 	},
 	chat: {
-		actionAdd: 'SOURCE_CHARACTER pushed a Dildo Gag into TARGET_CHARACTER_DYNAMIC_POSSESSIVE mouth, strapping it tight.',
-		actionRemove: 'SOURCE_CHARACTER loosened and then removed the Dildo Gag from TARGET_CHARACTER_DYNAMIC_POSSESSIVE mouth.',
+		actionAdd: 'SOURCE_CHARACTER pushed ITEM_ASSET_NAME into TARGET_CHARACTER_DYNAMIC_POSSESSIVE mouth, strapping it tight.',
+		actionRemove: 'SOURCE_CHARACTER loosened and then removed ITEM_ASSET_NAME from TARGET_CHARACTER_DYNAMIC_POSSESSIVE mouth.',
 	},
 	ownership: {
 		responsibleContributor: 'ClaudiaMia <99583892+ClaudiaMia@users.noreply.github.com>',

--- a/src/assets/gags/duct_tape/duct_tape.asset.ts
+++ b/src/assets/gags/duct_tape/duct_tape.asset.ts
@@ -69,8 +69,8 @@ DefineAsset({
 		},
 	},
 	chat: {
-		actionAdd: 'SOURCE_CHARACTER sealed TARGET_CHARACTER_DYNAMIC_POSSESSIVE mouth with duct tape.',
-		actionRemove: 'SOURCE_CHARACTER removed the tape from TARGET_CHARACTER_DYNAMIC_POSSESSIVE mouth.',
+		actionAdd: 'SOURCE_CHARACTER sealed TARGET_CHARACTER_DYNAMIC_POSSESSIVE mouth with ITEM_ASSET_NAME.',
+		actionRemove: 'SOURCE_CHARACTER removed ITEM_ASSET_NAME from TARGET_CHARACTER_DYNAMIC_POSSESSIVE mouth.',
 	},
 	ownership: {
 		responsibleContributor: 'Sandrine <118102950+SandrinePDR@users.noreply.github.com>',

--- a/src/assets/gags/jute_rope_gag/jute_rope_gag.asset.ts
+++ b/src/assets/gags/jute_rope_gag/jute_rope_gag.asset.ts
@@ -115,8 +115,8 @@ DefineAsset({
 		},
 	},
 	chat: {
-		actionAdd: 'SOURCE_CHARACTER tied a Rope Gag tightly between TARGET_CHARACTER_DYNAMIC_POSSESSIVE teeth.',
-		actionRemove: 'SOURCE_CHARACTER loosened and then removed the Rope Gag from TARGET_CHARACTER_DYNAMIC_POSSESSIVE mouth.',
+		actionAdd: 'SOURCE_CHARACTER tied ITEM_ASSET_NAME tightly between TARGET_CHARACTER_DYNAMIC_POSSESSIVE teeth.',
+		actionRemove: 'SOURCE_CHARACTER loosened and then removed ITEM_ASSET_NAME from TARGET_CHARACTER_DYNAMIC_POSSESSIVE mouth.',
 	},
 	ownership: {
 		responsibleContributor: 'Shikifet <shikifet@gmail.com>',

--- a/src/assets/gags/large_ballgag/large_ballgag.asset.ts
+++ b/src/assets/gags/large_ballgag/large_ballgag.asset.ts
@@ -69,8 +69,8 @@ DefineAsset({
 		stimulus: 2,
 	},
 	chat: {
-		actionAdd: 'SOURCE_CHARACTER strapped a Large Ball Gag tightly between TARGET_CHARACTER_DYNAMIC_POSSESSIVE lips.',
-		actionRemove: 'SOURCE_CHARACTER loosened and then removed the Large Ball Gag from TARGET_CHARACTER_DYNAMIC_POSSESSIVE mouth.',
+		actionAdd: 'SOURCE_CHARACTER strapped ITEM_ASSET_NAME tightly between TARGET_CHARACTER_DYNAMIC_POSSESSIVE lips.',
+		actionRemove: 'SOURCE_CHARACTER loosened and then removed ITEM_ASSET_NAME from TARGET_CHARACTER_DYNAMIC_POSSESSIVE mouth.',
 	},
 	ownership: {
 		responsibleContributor: 'ClaudiaMia <99583892+ClaudiaMia@users.noreply.github.com>',

--- a/src/assets/gags/pluggag/pluggag.asset.ts
+++ b/src/assets/gags/pluggag/pluggag.asset.ts
@@ -138,8 +138,8 @@ DefineAsset({
 		},
 	},
 	chat: {
-		actionAdd: 'SOURCE_CHARACTER strapped a Plug Gag tightly between TARGET_CHARACTER_DYNAMIC_POSSESSIVE lips.',
-		actionRemove: 'SOURCE_CHARACTER loosened and then removed the Plug Gag from TARGET_CHARACTER_DYNAMIC_POSSESSIVE mouth.',
+		actionAdd: 'SOURCE_CHARACTER strapped ITEM_ASSET_NAME tightly between TARGET_CHARACTER_DYNAMIC_POSSESSIVE lips.',
+		actionRemove: 'SOURCE_CHARACTER loosened and then removed ITEM_ASSET_NAME from TARGET_CHARACTER_DYNAMIC_POSSESSIVE mouth.',
 	},
 	ownership: {
 		responsibleContributor: 'ClaudiaMia <99583892+ClaudiaMia@users.noreply.github.com>',

--- a/src/assets/gags/ringgag/ringgag.asset.ts
+++ b/src/assets/gags/ringgag/ringgag.asset.ts
@@ -64,8 +64,8 @@ DefineAsset({
 		stimulus: 2,
 	},
 	chat: {
-		actionAdd: 'SOURCE_CHARACTER strapped a Ring Gag tightly between TARGET_CHARACTER_DYNAMIC_POSSESSIVE teeth.',
-		actionRemove: 'SOURCE_CHARACTER loosened and then removed the Ring Gag from TARGET_CHARACTER_DYNAMIC_POSSESSIVE mouth.',
+		actionAdd: 'SOURCE_CHARACTER strapped ITEM_ASSET_NAME tightly between TARGET_CHARACTER_DYNAMIC_POSSESSIVE teeth.',
+		actionRemove: 'SOURCE_CHARACTER loosened and then removed ITEM_ASSET_NAME from TARGET_CHARACTER_DYNAMIC_POSSESSIVE mouth.',
 	},
 	ownership: {
 		responsibleContributor: 'ClaudiaMia <99583892+ClaudiaMia@users.noreply.github.com>',

--- a/src/assets/gags/stuffing/stuffing.asset.ts
+++ b/src/assets/gags/stuffing/stuffing.asset.ts
@@ -33,8 +33,8 @@ DefineAsset({
 		stimulus: 1,
 	},
 	chat: {
-		actionAdd: 'SOURCE_CHARACTER stuffed TARGET_CHARACTER_DYNAMIC_POSSESSIVE mouth.',
-		actionRemove: 'SOURCE_CHARACTER removed the stuffing in TARGET_CHARACTER_DYNAMIC_POSSESSIVE mouth.',
+		actionAdd: 'SOURCE_CHARACTER used ITEM_ASSET_NAME on TARGET_CHARACTER_DYNAMIC_POSSESSIVE mouth.',
+		actionRemove: 'SOURCE_CHARACTER removed the ITEM_ASSET_NAME in TARGET_CHARACTER_DYNAMIC_POSSESSIVE mouth.',
 	},
 	ownership: {
 		responsibleContributor: 'ClaudiaMia <99583892+ClaudiaMia@users.noreply.github.com>',

--- a/src/assets/gags/tongue_strap/tongue_strap.asset.ts
+++ b/src/assets/gags/tongue_strap/tongue_strap.asset.ts
@@ -58,8 +58,8 @@ DefineAsset({
 		stimulus: 3,
 	},
 	chat: {
-		actionAdd: 'SOURCE_CHARACTER strapped a Tongue Strap securely around TARGET_CHARACTER_DYNAMIC_POSSESSIVE tongue.',
-		actionRemove: 'SOURCE_CHARACTER loosened and then removed the Tongue Strap from TARGET_CHARACTER_DYNAMIC_POSSESSIVE mouth.',
+		actionAdd: 'SOURCE_CHARACTER strapped ITEM_ASSET_NAME securely around TARGET_CHARACTER_DYNAMIC_POSSESSIVE tongue.',
+		actionRemove: 'SOURCE_CHARACTER loosened and then removed ITEM_ASSET_NAME from TARGET_CHARACTER_DYNAMIC_POSSESSIVE mouth.',
 	},
 	ownership: {
 		responsibleContributor: 'ClaudiaMia <99583892+ClaudiaMia@users.noreply.github.com>',

--- a/src/assets/gags/wifflegag/wifflegag.asset.ts
+++ b/src/assets/gags/wifflegag/wifflegag.asset.ts
@@ -69,8 +69,8 @@ DefineAsset({
 		stimulus: 2,
 	},
 	chat: {
-		actionAdd: 'SOURCE_CHARACTER strapped a Wiffle Gag tightly between TARGET_CHARACTER_DYNAMIC_POSSESSIVE lips.',
-		actionRemove: 'SOURCE_CHARACTER loosened and then removed the Wiffle Gag from TARGET_CHARACTER_DYNAMIC_POSSESSIVE mouth.',
+		actionAdd: 'SOURCE_CHARACTER strapped ITEM_ASSET_NAME tightly between TARGET_CHARACTER_DYNAMIC_POSSESSIVE lips.',
+		actionRemove: 'SOURCE_CHARACTER loosened and then removed ITEM_ASSET_NAME from TARGET_CHARACTER_DYNAMIC_POSSESSIVE mouth.',
 	},
 	ownership: {
 		responsibleContributor: 'ClaudiaMia <99583892+ClaudiaMia@users.noreply.github.com>',

--- a/src/assets/handhelds/cane/cane.asset.ts
+++ b/src/assets/handhelds/cane/cane.asset.ts
@@ -72,8 +72,8 @@ DefineAsset({
 		},
 	},
 	chat: {
-		actionAdd: 'SOURCE_CHARACTER put a cane into TARGET_CHARACTER_DYNAMIC_POSSESSIVE hand.',
-		actionRemove: 'SOURCE_CHARACTER removed the cane from TARGET_CHARACTER_DYNAMIC_POSSESSIVE hand.',
+		actionAdd: 'SOURCE_CHARACTER put ITEM_ASSET_NAME into TARGET_CHARACTER_DYNAMIC_POSSESSIVE hand.',
+		actionRemove: 'SOURCE_CHARACTER removed ITEM_ASSET_NAME from TARGET_CHARACTER_DYNAMIC_POSSESSIVE hand.',
 	},
 	ownership: {
 		responsibleContributor: 'ClaudiaMia <99583892+ClaudiaMia@users.noreply.github.com>',

--- a/src/assets/handhelds/crop/crop.asset.ts
+++ b/src/assets/handhelds/crop/crop.asset.ts
@@ -91,8 +91,8 @@ DefineAsset({
 		},
 	},
 	chat: {
-		actionAdd: 'SOURCE_CHARACTER put a crop into TARGET_CHARACTER_DYNAMIC_POSSESSIVE hand.',
-		actionRemove: 'SOURCE_CHARACTER removed the crop from TARGET_CHARACTER_DYNAMIC_POSSESSIVE hand.',
+		actionAdd: 'SOURCE_CHARACTER put ITEM_ASSET_NAME into TARGET_CHARACTER_DYNAMIC_POSSESSIVE hand.',
+		actionRemove: 'SOURCE_CHARACTER removed ITEM_ASSET_NAME from TARGET_CHARACTER_DYNAMIC_POSSESSIVE hand.',
 	},
 	ownership: {
 		responsibleContributor: 'ClaudiaMia <99583892+ClaudiaMia@users.noreply.github.com>',

--- a/src/assets/handhelds/flogger/flogger.asset.ts
+++ b/src/assets/handhelds/flogger/flogger.asset.ts
@@ -83,8 +83,8 @@ DefineAsset({
 		},
 	},
 	chat: {
-		actionAdd: 'SOURCE_CHARACTER put a flogger into TARGET_CHARACTER_DYNAMIC_POSSESSIVE hand.',
-		actionRemove: 'SOURCE_CHARACTER removed the flogger from TARGET_CHARACTER_DYNAMIC_POSSESSIVE hand.',
+		actionAdd: 'SOURCE_CHARACTER put ITEM_ASSET_NAME into TARGET_CHARACTER_DYNAMIC_POSSESSIVE hand.',
+		actionRemove: 'SOURCE_CHARACTER removed ITEM_ASSET_NAME from TARGET_CHARACTER_DYNAMIC_POSSESSIVE hand.',
 	},
 	ownership: {
 		responsibleContributor: 'ClaudiaMia <99583892+ClaudiaMia@users.noreply.github.com>',

--- a/src/assets/handhelds/lotion_bottle/lotion_bottle.asset.ts
+++ b/src/assets/handhelds/lotion_bottle/lotion_bottle.asset.ts
@@ -78,8 +78,8 @@ DefineAsset({
 		},
 	},
 	chat: {
-		actionAdd: 'SOURCE_CHARACTER put a bottle with lotion into TARGET_CHARACTER_DYNAMIC_POSSESSIVE hand.',
-		actionRemove: 'SOURCE_CHARACTER removed the lotion bottle from TARGET_CHARACTER_DYNAMIC_POSSESSIVE hand.',
+		actionAdd: 'SOURCE_CHARACTER put ITEM_ASSET_NAME into TARGET_CHARACTER_DYNAMIC_POSSESSIVE hand.',
+		actionRemove: 'SOURCE_CHARACTER removed ITEM_ASSET_NAME from TARGET_CHARACTER_DYNAMIC_POSSESSIVE hand.',
 	},
 	ownership: {
 		responsibleContributor: 'Sandrine <118102950+SandrinePDR@users.noreply.github.com>',

--- a/src/assets/handhelds/mug/mug.asset.ts
+++ b/src/assets/handhelds/mug/mug.asset.ts
@@ -111,8 +111,8 @@ DefineAsset({
 		},
 	},
 	chat: {
-		actionAdd: 'SOURCE_CHARACTER put a mug into TARGET_CHARACTER_DYNAMIC_POSSESSIVE hand.',
-		actionRemove: 'SOURCE_CHARACTER removed the mug from TARGET_CHARACTER_DYNAMIC_POSSESSIVE hand.',
+		actionAdd: 'SOURCE_CHARACTER put ITEM_ASSET_NAME into TARGET_CHARACTER_DYNAMIC_POSSESSIVE hand.',
+		actionRemove: 'SOURCE_CHARACTER removed ITEM_ASSET_NAME from TARGET_CHARACTER_DYNAMIC_POSSESSIVE hand.',
 	},
 	ownership: {
 		responsibleContributor: 'Sandrine <118102950+SandrinePDR@users.noreply.github.com>',

--- a/src/assets/handhelds/paddle/paddle.asset.ts
+++ b/src/assets/handhelds/paddle/paddle.asset.ts
@@ -68,8 +68,8 @@ DefineAsset({
 		},
 	},
 	chat: {
-		actionAdd: 'SOURCE_CHARACTER put a paddle into TARGET_CHARACTER_DYNAMIC_POSSESSIVE hand.',
-		actionRemove: 'SOURCE_CHARACTER removed the paddle from TARGET_CHARACTER_DYNAMIC_POSSESSIVE hand.',
+		actionAdd: 'SOURCE_CHARACTER put ITEM_ASSET_NAME into TARGET_CHARACTER_DYNAMIC_POSSESSIVE hand.',
+		actionRemove: 'SOURCE_CHARACTER removed ITEM_ASSET_NAME from TARGET_CHARACTER_DYNAMIC_POSSESSIVE hand.',
 	},
 	ownership: {
 		responsibleContributor: 'ClaudiaMia <99583892+ClaudiaMia@users.noreply.github.com>',

--- a/src/assets/handhelds/room_construction_tools/room_construction_tools.asset.ts
+++ b/src/assets/handhelds/room_construction_tools/room_construction_tools.asset.ts
@@ -54,8 +54,8 @@ DefineAsset({
 		},
 	},
 	chat: {
-		actionAdd: 'SOURCE_CHARACTER put a toolbox into TARGET_CHARACTER_DYNAMIC_POSSESSIVE hand.',
-		actionRemove: 'SOURCE_CHARACTER removed the toolbox from TARGET_CHARACTER_DYNAMIC_POSSESSIVE hand.',
+		actionAdd: 'SOURCE_CHARACTER put ITEM_ASSET_NAME into TARGET_CHARACTER_DYNAMIC_POSSESSIVE hand.',
+		actionRemove: 'SOURCE_CHARACTER removed ITEM_ASSET_NAME from TARGET_CHARACTER_DYNAMIC_POSSESSIVE hand.',
 	},
 	ownership: {
 		responsibleContributor: 'ClaudiaMia <99583892+ClaudiaMia@users.noreply.github.com>',

--- a/src/assets/handhelds/slapper/slapper.asset.ts
+++ b/src/assets/handhelds/slapper/slapper.asset.ts
@@ -72,8 +72,8 @@ DefineAsset({
 		},
 	},
 	chat: {
-		actionAdd: 'SOURCE_CHARACTER put a slapper into TARGET_CHARACTER_DYNAMIC_POSSESSIVE hand.',
-		actionRemove: 'SOURCE_CHARACTER removed the slapper from TARGET_CHARACTER_DYNAMIC_POSSESSIVE hand.',
+		actionAdd: 'SOURCE_CHARACTER put ITEM_ASSET_NAME into TARGET_CHARACTER_DYNAMIC_POSSESSIVE hand.',
+		actionRemove: 'SOURCE_CHARACTER removed ITEM_ASSET_NAME from TARGET_CHARACTER_DYNAMIC_POSSESSIVE hand.',
 	},
 	ownership: {
 		responsibleContributor: 'ClaudiaMia <99583892+ClaudiaMia@users.noreply.github.com>',

--- a/src/assets/handhelds/tea_cup/tea_cup.asset.ts
+++ b/src/assets/handhelds/tea_cup/tea_cup.asset.ts
@@ -115,8 +115,8 @@ DefineAsset({
 		},
 	},
 	chat: {
-		actionAdd: 'SOURCE_CHARACTER put a delicate cup into TARGET_CHARACTER_DYNAMIC_POSSESSIVE hand.',
-		actionRemove: 'SOURCE_CHARACTER removed the delicate cup from TARGET_CHARACTER_DYNAMIC_POSSESSIVE hand.',
+		actionAdd: 'SOURCE_CHARACTER put ITEM_ASSET_NAME into TARGET_CHARACTER_DYNAMIC_POSSESSIVE hand.',
+		actionRemove: 'SOURCE_CHARACTER removed ITEM_ASSET_NAME from TARGET_CHARACTER_DYNAMIC_POSSESSIVE hand.',
 	},
 	ownership: {
 		responsibleContributor: 'Sandrine <118102950+SandrinePDR@users.noreply.github.com>',

--- a/src/assets/handhelds/vibe_wand/vibe_wand.asset.ts
+++ b/src/assets/handhelds/vibe_wand/vibe_wand.asset.ts
@@ -72,8 +72,8 @@ DefineAsset({
 		},
 	},
 	chat: {
-		actionAdd: 'SOURCE_CHARACTER put a vibe wand into TARGET_CHARACTER_DYNAMIC_POSSESSIVE hand.',
-		actionRemove: 'SOURCE_CHARACTER removed the vibe wand from TARGET_CHARACTER_DYNAMIC_POSSESSIVE hand.',
+		actionAdd: 'SOURCE_CHARACTER put ITEM_ASSET_NAME into TARGET_CHARACTER_DYNAMIC_POSSESSIVE hand.',
+		actionRemove: 'SOURCE_CHARACTER removed ITEM_ASSET_NAME from TARGET_CHARACTER_DYNAMIC_POSSESSIVE hand.',
 	},
 	ownership: {
 		responsibleContributor: 'ClaudiaMia <99583892+ClaudiaMia@users.noreply.github.com>',

--- a/src/assets/locks/combination_lock/combination_lock.asset.ts
+++ b/src/assets/locks/combination_lock/combination_lock.asset.ts
@@ -9,8 +9,8 @@ DefineLockAsset({
 	},
 	chat: {
 		chatDescriptor: 'a combination lock',
-		actionLock: 'SOURCE_CHARACTER clicked the combination lock on ITEM_CONTAINER_SIMPLE_DYNAMIC shut.',
-		actionUnlock: 'SOURCE_CHARACTER unlocked the combination lock on ITEM_CONTAINER_SIMPLE_DYNAMIC.',
+		actionLock: 'SOURCE_CHARACTER clicked ITEM_ASSET_NAME on ITEM_CONTAINER_SIMPLE_DYNAMIC shut.',
+		actionUnlock: 'SOURCE_CHARACTER unlocked ITEM_ASSET_NAME on ITEM_CONTAINER_SIMPLE_DYNAMIC.',
 	},
 	ownership: {
 		responsibleContributor: 'Sekkmer <sekkmer@gmail.com>',

--- a/src/assets/locks/dummy_lock/dummy_lock.asset.ts
+++ b/src/assets/locks/dummy_lock/dummy_lock.asset.ts
@@ -3,8 +3,8 @@ DefineLockAsset({
 	lockSetup: {},
 	chat: {
 		chatDescriptor: 'a dummy lock',
-		actionLock: 'SOURCE_CHARACTER clicked the dummy lock on ITEM_CONTAINER_SIMPLE_DYNAMIC shut.',
-		actionUnlock: 'SOURCE_CHARACTER unlocked the dummy lock on ITEM_CONTAINER_SIMPLE_DYNAMIC.',
+		actionLock: 'SOURCE_CHARACTER clicked ITEM_ASSET_NAME on ITEM_CONTAINER_SIMPLE_DYNAMIC shut.',
+		actionUnlock: 'SOURCE_CHARACTER unlocked ITEM_ASSET_NAME on ITEM_CONTAINER_SIMPLE_DYNAMIC.',
 	},
 	ownership: {
 		responsibleContributor: 'Jomshir98 <jomshir98@protonmail.com>',

--- a/src/assets/locks/easy_combination_lock/easy_combination_lock.asset.ts
+++ b/src/assets/locks/easy_combination_lock/easy_combination_lock.asset.ts
@@ -9,8 +9,8 @@ DefineLockAsset({
 	},
 	chat: {
 		chatDescriptor: 'an easy combination lock',
-		actionLock: 'SOURCE_CHARACTER clicked the easy combination lock on ITEM_CONTAINER_SIMPLE_DYNAMIC shut.',
-		actionUnlock: 'SOURCE_CHARACTER unlocked the easy combination lock on ITEM_CONTAINER_SIMPLE_DYNAMIC.',
+		actionLock: 'SOURCE_CHARACTER clicked ITEM_ASSET_NAME on ITEM_CONTAINER_SIMPLE_DYNAMIC shut.',
+		actionUnlock: 'SOURCE_CHARACTER unlocked ITEM_ASSET_NAME on ITEM_CONTAINER_SIMPLE_DYNAMIC.',
 	},
 	ownership: {
 		responsibleContributor: 'Sekkmer <sekkmer@gmail.com>',

--- a/src/assets/locks/exclusive_lock/exclusive_lock.asset.ts
+++ b/src/assets/locks/exclusive_lock/exclusive_lock.asset.ts
@@ -5,8 +5,8 @@ DefineLockAsset({
 	},
 	chat: {
 		chatDescriptor: 'an exclusive lock',
-		actionLock: 'SOURCE_CHARACTER clicked the exclusive lock on ITEM_CONTAINER_SIMPLE_DYNAMIC shut.',
-		actionUnlock: 'SOURCE_CHARACTER unlocked the exclusive lock on ITEM_CONTAINER_SIMPLE_DYNAMIC.',
+		actionLock: 'SOURCE_CHARACTER clicked ITEM_ASSET_NAME on ITEM_CONTAINER_SIMPLE_DYNAMIC shut.',
+		actionUnlock: 'SOURCE_CHARACTER unlocked ITEM_ASSET_NAME on ITEM_CONTAINER_SIMPLE_DYNAMIC.',
 	},
 	ownership: {
 		responsibleContributor: 'Jomshir98 <jomshir98@protonmail.com>',

--- a/src/assets/locks/password_lock/password_lock.asset.ts
+++ b/src/assets/locks/password_lock/password_lock.asset.ts
@@ -9,8 +9,8 @@ DefineLockAsset({
 	},
 	chat: {
 		chatDescriptor: 'a password lock',
-		actionLock: 'SOURCE_CHARACTER clicked the password lock on ITEM_CONTAINER_SIMPLE_DYNAMIC shut.',
-		actionUnlock: 'SOURCE_CHARACTER unlocked the password lock on ITEM_CONTAINER_SIMPLE_DYNAMIC.',
+		actionLock: 'SOURCE_CHARACTER clicked ITEM_ASSET_NAME on ITEM_CONTAINER_SIMPLE_DYNAMIC shut.',
+		actionUnlock: 'SOURCE_CHARACTER unlocked ITEM_ASSET_NAME on ITEM_CONTAINER_SIMPLE_DYNAMIC.',
 	},
 	ownership: {
 		responsibleContributor: 'Sekkmer <sekkmer@gmail.com>',

--- a/src/assets/misc/pocketDimension/pocketDimension.asset.ts
+++ b/src/assets/misc/pocketDimension/pocketDimension.asset.ts
@@ -12,8 +12,8 @@ DefineAsset({
 	},
 	chat: {
 		chatDescriptor: 'pocket dimension',
-		actionAdd: 'SOURCE_CHARACTER summoned a pocket dimension for TARGET_CHARACTER_DYNAMIC_REFLEXIVE.',
-		actionRemove: 'SOURCE_CHARACTER dispelled TARGET_CHARACTER_DYNAMIC_POSSESSIVE pocket dimension.',
+		actionAdd: 'SOURCE_CHARACTER summoned ITEM_ASSET_NAME for TARGET_CHARACTER_DYNAMIC_REFLEXIVE.',
+		actionRemove: 'SOURCE_CHARACTER dispelled TARGET_CHARACTER_DYNAMIC_POSSESSIVE ITEM_ASSET_NAME.',
 	},
 	ownership: {
 		responsibleContributor: 'Jomshir98 <jomshir98@protonmail.com>',

--- a/src/assets/panties/crotch_jute_rope/crotch_jute_rope.asset.ts
+++ b/src/assets/panties/crotch_jute_rope/crotch_jute_rope.asset.ts
@@ -128,8 +128,8 @@ DefineAsset({
 		},
 	},
 	chat: {
-		actionAdd: 'SOURCE_CHARACTER tied Crotch Jute Ropes around TARGET_CHARACTER_DYNAMIC_POSSESSIVE body.',
-		actionRemove: 'SOURCE_CHARACTER removed the Crotch Jute Ropes from TARGET_CHARACTER_DYNAMIC_POSSESSIVE body.',
+		actionAdd: 'SOURCE_CHARACTER tied ITEM_ASSET_NAME around TARGET_CHARACTER_DYNAMIC_POSSESSIVE body.',
+		actionRemove: 'SOURCE_CHARACTER removed ITEM_ASSET_NAME from TARGET_CHARACTER_DYNAMIC_POSSESSIVE body.',
 	},
 	ownership: {
 		responsibleContributor: 'Shikifet <shikifet@gmail.com>',

--- a/src/assets/toys/chopsticks_nipple_clamps/chopsticks_nipple_clamps.asset.ts
+++ b/src/assets/toys/chopsticks_nipple_clamps/chopsticks_nipple_clamps.asset.ts
@@ -67,8 +67,8 @@ DefineAsset({
 		},
 	},
 	chat: {
-		actionAdd: 'SOURCE_CHARACTER attached Chopsticks Nipple Clamps to both of TARGET_CHARACTER_DYNAMIC_POSSESSIVE nipples.',
-		actionRemove: 'SOURCE_CHARACTER removed the Chopsticks Nipple Clamps from TARGET_CHARACTER_DYNAMIC_POSSESSIVE nipples.',
+		actionAdd: 'SOURCE_CHARACTER attached ITEM_ASSET_NAME to both of TARGET_CHARACTER_DYNAMIC_POSSESSIVE nipples.',
+		actionRemove: 'SOURCE_CHARACTER removed ITEM_ASSET_NAME from TARGET_CHARACTER_DYNAMIC_POSSESSIVE nipples.',
 	},
 	ownership: {
 		responsibleContributor: 'Shikifet <shikifet@gmail.com>',

--- a/src/assets/toys/genital_clamps/genital_clamps.asset.ts
+++ b/src/assets/toys/genital_clamps/genital_clamps.asset.ts
@@ -57,8 +57,8 @@ DefineAsset({
 		},
 	},
 	chat: {
-		actionAdd: 'SOURCE_CHARACTER attached Genital Clamps to TARGET_CHARACTER_DYNAMIC_POSSESSIVE genitals.',
-		actionRemove: 'SOURCE_CHARACTER removed the Genital Clamps from TARGET_CHARACTER_DYNAMIC_POSSESSIVE genitals.',
+		actionAdd: 'SOURCE_CHARACTER attached ITEM_ASSET_NAME to TARGET_CHARACTER_DYNAMIC_POSSESSIVE genitals.',
+		actionRemove: 'SOURCE_CHARACTER removed ITEM_ASSET_NAME from TARGET_CHARACTER_DYNAMIC_POSSESSIVE genitals.',
 	},
 	ownership: {
 		responsibleContributor: 'ClaudiaMia <99583892+ClaudiaMia@users.noreply.github.com>',

--- a/src/assets/toys/nipple_clamps/nipple_clamps.asset.ts
+++ b/src/assets/toys/nipple_clamps/nipple_clamps.asset.ts
@@ -62,8 +62,8 @@ DefineAsset({
 		},
 	},
 	chat: {
-		actionAdd: 'SOURCE_CHARACTER attached Nipple Clamps to both of TARGET_CHARACTER_DYNAMIC_POSSESSIVE nipples.',
-		actionRemove: 'SOURCE_CHARACTER removed the Nipple Clamps from TARGET_CHARACTER_DYNAMIC_POSSESSIVE nipples.',
+		actionAdd: 'SOURCE_CHARACTER attached ITEM_ASSET_NAME to both of TARGET_CHARACTER_DYNAMIC_POSSESSIVE nipples.',
+		actionRemove: 'SOURCE_CHARACTER removed ITEM_ASSET_NAME from TARGET_CHARACTER_DYNAMIC_POSSESSIVE nipples.',
 	},
 	ownership: {
 		responsibleContributor: 'ClaudiaMia <99583892+ClaudiaMia@users.noreply.github.com>',

--- a/src/tools/definitionBodypart.ts
+++ b/src/tools/definitionBodypart.ts
@@ -1,5 +1,5 @@
 import { freeze } from 'immer';
-import { cloneDeep, pick } from 'lodash-es';
+import { cloneDeep, omit, pick } from 'lodash-es';
 import { AssetId, BodypartAssetDefinition, GetLogger } from 'pandora-common';
 import { join } from 'path';
 import { AssetDatabase } from './assetDatabase.js';
@@ -10,6 +10,7 @@ import { RegisterImportContextProcess } from './importContext.js';
 import { ValidateOwnershipData } from './licensing.js';
 import { LoadAssetColorization } from './load_helpers/color.js';
 import { DefinePngResource, PREVIEW_SIZE } from './resources.js';
+import { ValidateAssetChatMessages } from './validation/chatMessages.js';
 import { ValidateAllModules } from './validation/modules.js';
 import { PropertiesValidationMetadata, ValidateAssetProperties, ValidateAssetPropertiesFinalize } from './validation/properties.js';
 
@@ -92,6 +93,7 @@ async function GlobalDefineBodypartProcess(def: IntermediateBodypartAssetDefinit
 
 	// Validate base properties
 	ValidateAssetProperties(logger, '#', propertiesValidationMetadata, def);
+	ValidateAssetChatMessages(logger, '#.chat', omit(def.chat, ['chatDescriptor']));
 
 	// Validate all modules
 	propertiesValidationMetadata.context = 'module';

--- a/src/tools/definitionLock.ts
+++ b/src/tools/definitionLock.ts
@@ -1,11 +1,12 @@
 import { freeze } from 'immer';
-import { cloneDeep, pick } from 'lodash-es';
+import { cloneDeep, omit, pick } from 'lodash-es';
 import { AssetId, GetLogger, LockAssetDefinition } from 'pandora-common';
 import { AssetDatabase } from './assetDatabase.js';
 import { DefaultId } from './context.js';
 import { RegisterImportContextProcess } from './importContext.js';
 import { ValidateOwnershipData } from './licensing.js';
 import { DefinePngResource, PREVIEW_SIZE } from './resources.js';
+import { ValidateAssetChatMessages } from './validation/chatMessages.js';
 
 const LOCK_DEFINITION_FALLTHROUGH_PROPERTIES = [
 	// Asset definition
@@ -30,6 +31,9 @@ async function GlobalDefineLockAssetProcess(def: IntermediateLockAssetDefinition
 	const id: AssetId = `a/${def.id ?? DefaultId()}` as const;
 
 	const logger = GetLogger(`DefineLockAsset`, `[Asset ${id}]`);
+
+	// Validate properties
+	ValidateAssetChatMessages(logger, '#.chat', omit(def.chat, ['chatDescriptor']));
 
 	// Validate ownership data
 	ValidateOwnershipData(def.ownership, logger, false);

--- a/src/tools/definitionPersonal.ts
+++ b/src/tools/definitionPersonal.ts
@@ -1,5 +1,5 @@
 import { freeze } from 'immer';
-import { cloneDeep, pick } from 'lodash-es';
+import { cloneDeep, omit, pick } from 'lodash-es';
 import { AssetId, GetLogger, PersonalAssetDefinition } from 'pandora-common';
 import { join } from 'path';
 import { AssetDatabase } from './assetDatabase.js';
@@ -10,6 +10,7 @@ import { RegisterImportContextProcess } from './importContext.js';
 import { ValidateOwnershipData } from './licensing.js';
 import { LoadAssetColorization } from './load_helpers/color.js';
 import { DefinePngResource, PREVIEW_SIZE } from './resources.js';
+import { ValidateAssetChatMessages } from './validation/chatMessages.js';
 import { ValidateAllModules } from './validation/modules.js';
 import { PropertiesValidationMetadata, ValidateAssetProperties, ValidateAssetPropertiesFinalize } from './validation/properties.js';
 
@@ -98,6 +99,7 @@ async function GlobalDefineAssetProcess(def: IntermediatePersonalAssetDefinition
 
 	// Validate base properties
 	ValidateAssetProperties(logger, '#', propertiesValidationMetadata, def);
+	ValidateAssetChatMessages(logger, '#.chat', omit(def.chat, ['chatDescriptor']));
 
 	// Validate all modules
 	propertiesValidationMetadata.context = 'module';

--- a/src/tools/definitionRoomDevice.ts
+++ b/src/tools/definitionRoomDevice.ts
@@ -1,5 +1,5 @@
 import { freeze } from 'immer';
-import { cloneDeep, pick } from 'lodash-es';
+import { cloneDeep, omit, pick } from 'lodash-es';
 import { Assert, AssertNever, AssetId, GetLogger, RoomDeviceAssetDefinition, RoomDeviceModuleStaticData, RoomDeviceProperties, RoomDeviceWearablePartAssetDefinition } from 'pandora-common';
 import { join } from 'path';
 import { OPTIMIZE_TEXTURES } from '../constants.js';
@@ -11,6 +11,7 @@ import { RegisterImportContextProcess } from './importContext.js';
 import { ValidateOwnershipData } from './licensing.js';
 import { LoadRoomDeviceColorization } from './load_helpers/color.js';
 import { DefineImageResource, DefinePngResource, IImageResource, ImageBoundingBox, PREVIEW_SIZE } from './resources.js';
+import { ValidateAssetChatMessages } from './validation/chatMessages.js';
 import { ValidateAllModules } from './validation/modules.js';
 import { ValidateAssetProperties, ValidateAssetPropertiesFinalize } from './validation/properties.js';
 import { RoomDevicePropertiesValidationMetadata, ValidateRoomDeviceProperties } from './validation/roomDeviceProperties.js';
@@ -91,6 +92,7 @@ async function DefineRoomDeviceWearablePart(
 	};
 
 	ValidateAssetProperties(logger, '#', propertiesValidationMetadata, def);
+	ValidateAssetChatMessages(logger, '#.chat', omit(def.chat, ['chatDescriptor']));
 
 	if (!definitionValid) {
 		logger.error('Invalid asset definition, asset skipped');
@@ -297,6 +299,9 @@ async function GlobalDefineRoomDeviceAssetProcess(def: IntermediateRoomDeviceDef
 		preview,
 		slots,
 	};
+
+	// Validate properties
+	ValidateAssetChatMessages(logger, '#.chat', omit(def.chat, ['chatDescriptor']));
 
 	// Validate all modules
 	propertiesValidationMetadata.context = 'module';

--- a/src/tools/validation/chatMessages.ts
+++ b/src/tools/validation/chatMessages.ts
@@ -1,0 +1,80 @@
+import type { Logger } from 'pandora-common';
+
+type MessageRequirementRule = {
+	name: string;
+	match: readonly string[];
+};
+const ASSET_MESSAGES_REQUIREMENTS: readonly MessageRequirementRule[] = [
+	{
+		name: 'Source character name',
+		match: [
+			'SOURCE_CHARACTER',
+			'SOURCE_CHARACTER_POSSESSIVE',
+			'SOURCE_CHARACTER_NAME',
+		],
+	},
+	{
+		name: 'Source character id',
+		match: [
+			'SOURCE_CHARACTER',
+			'SOURCE_CHARACTER_POSSESSIVE',
+			'SOURCE_CHARACTER_ID',
+		],
+	},
+	{
+		name: 'Target character name',
+		match: [
+			'TARGET_CHARACTER',
+			'TARGET_CHARACTER_POSSESSIVE',
+			'TARGET_CHARACTER_NAME',
+			'TARGET_CHARACTER_DYNAMIC_SUBJECTIVE',
+			'TARGET_CHARACTER_DYNAMIC_OBJECTIVE',
+			'TARGET_CHARACTER_DYNAMIC_POSSESSIVE',
+			'TARGET_CHARACTER_DYNAMIC_REFLEXIVE',
+			'ITEM_CONTAINER_SIMPLE',
+			'ITEM_CONTAINER_SIMPLE_DYNAMIC',
+		],
+	},
+	{
+		name: 'Target character id',
+		match: [
+			'TARGET_CHARACTER',
+			'TARGET_CHARACTER_POSSESSIVE',
+			'TARGET_CHARACTER_ID',
+			'TARGET_CHARACTER_DYNAMIC_SUBJECTIVE',
+			'TARGET_CHARACTER_DYNAMIC_OBJECTIVE',
+			'TARGET_CHARACTER_DYNAMIC_POSSESSIVE',
+			'TARGET_CHARACTER_DYNAMIC_REFLEXIVE',
+			'ITEM_CONTAINER_SIMPLE',
+			'ITEM_CONTAINER_SIMPLE_DYNAMIC',
+		],
+	},
+	{
+		name: 'Item name (with support for custom names)',
+		match: [
+			'ITEM_ASSET_NAME',
+		],
+	},
+];
+
+export function ValidateAssetChatMessages(
+	logger: Logger,
+	context: string,
+	messages: Record<string, string | undefined> | undefined,
+): void {
+	for (const [key, message] of Object.entries(messages ?? {})) {
+		if (!message) // Ignore purposefully empty messages and unset keys
+			continue;
+
+		for (const validation of ASSET_MESSAGES_REQUIREMENTS) {
+			if (validation.match.some((m) => message.includes(m)))
+				continue;
+
+			logger.warning(
+				`[Chat] ${context}.${key}:\n\tMessage does not contain ${validation.name}.\n` +
+				`\tAdd one of the following substitution keys to support it:\n` +
+				validation.match.map((m) => '\t  - ' + m).join('\n'),
+			);
+		}
+	}
+}


### PR DESCRIPTION
## References

_None_

## About The Pull Request

Custom chat messages were mostly not supporting custom item names. This PR fixes that.

## Changelog

Authored by: Claudia

```md
Assets:
- All assets with custom add or remove chat messages now support custom item names in those messages

Asset creation changes:
- Custom add or remove chat messages now require certain info to be present (such as source and target characters and name of the item)
```

## Checklist

<!-- Checklist for you to make sure you didn't miss something -->
- [x] The change has been tested locally
- [x] Licensing information and credits were filled in/modified for added/modified assets
- [x] I understand this change is licensed based on [Pandora's Asset Licensing](https://github.com/Project-Pandora-Game/pandora-assets/blob/master/ASSET_LICENSING.md) information
