### PR TITLE
[FIX] reworked hand related attributes on applicable assets

### DIFF
--- a/src/assets/arm_restraints/armbinder/armbinder.asset.ts
+++ b/src/assets/arm_restraints/armbinder/armbinder.asset.ts
@@ -37,6 +37,7 @@ DefineAsset({
 		],
 		covers: [
 			'Hand_item',
+			'Hand_cover',
 			'Handheld',
 			'Wrist_cuffs',
 		],

--- a/src/assets/arm_restraints/canvas_straitjacket/canvas_straitjacket.asset.ts
+++ b/src/assets/arm_restraints/canvas_straitjacket/canvas_straitjacket.asset.ts
@@ -25,6 +25,7 @@ DefineAsset({
 		],
 		covers: [
 			'Hand_item',
+			'Hand_cover',
 			'Handheld',
 			'Wrist_cuffs',
 		],

--- a/src/assets/arm_restraints/inflatable_sleeping_bag/inflatable_sleeping_bag.asset.ts
+++ b/src/assets/arm_restraints/inflatable_sleeping_bag/inflatable_sleeping_bag.asset.ts
@@ -42,6 +42,7 @@ DefineAsset({
 			'Clothing_lower',
 			'Clothing_large',
 			'Hand_item',
+			'Hand_cover',
 			'Handheld',
 			'Restraint_arms',
 			'Restraint_legs',

--- a/src/assets/arm_restraints/mittens/mittens.asset.ts
+++ b/src/assets/arm_restraints/mittens/mittens.asset.ts
@@ -36,6 +36,7 @@ DefineAsset({
 		],
 		covers: [
 			'Hand_item',
+			'Hand_cover',
 			'Handheld',
 		],
 	},

--- a/src/assets/arm_restraints/paw_mittens/paw_mittens.asset.ts
+++ b/src/assets/arm_restraints/paw_mittens/paw_mittens.asset.ts
@@ -40,6 +40,7 @@ DefineAsset({
 		],
 		covers: [
 			'Hand_item',
+			'Hand_cover',
 			'Handheld',
 		],
 	},

--- a/src/assets/arm_restraints/steel_spheres/steel_spheres.asset.ts
+++ b/src/assets/arm_restraints/steel_spheres/steel_spheres.asset.ts
@@ -27,6 +27,7 @@ DefineAsset({
 		],
 		covers: [
 			'Hand_item',
+			'Hand_cover',
 			'Handheld',
 		],
 		hides: [

--- a/src/assets/body/eyes3/eyes3.asset.ts
+++ b/src/assets/body/eyes3/eyes3.asset.ts
@@ -66,10 +66,16 @@ DefineBodypart({
 					id: 'normal',
 					name: 'Open',
 					default: true,
+					properties: {
+						attributes: { provides: ['Eyes_left_open'] },
+					},
 				},
 				{
 					id: 'closed',
 					name: 'Closed',
+					properties: {
+						attributes: { provides: ['Eyes_left_closed'] },
+					},
 				},
 				{
 					id: 'blind',
@@ -78,6 +84,7 @@ DefineBodypart({
 						effects: {
 							blind: 4.99,
 						},
+						attributes: { provides: ['Eyes_left_closed'] },
 					},
 				},
 			],
@@ -91,10 +98,16 @@ DefineBodypart({
 					id: 'normal',
 					name: 'Open',
 					default: true,
+					properties: {
+						attributes: { provides: ['Eyes_right_open'] },
+					},
 				},
 				{
 					id: 'closed',
 					name: 'Closed',
+					properties: {
+						attributes: { provides: ['Eyes_right_closed'] },
+					},
 				},
 				{
 					id: 'blind',
@@ -103,6 +116,7 @@ DefineBodypart({
 						effects: {
 							blind: 4.99,
 						},
+						attributes: { provides: ['Eyes_right_closed'] },
 					},
 				},
 			],

--- a/src/assets/body/eyes4/eyes4.asset.ts
+++ b/src/assets/body/eyes4/eyes4.asset.ts
@@ -66,10 +66,16 @@ DefineBodypart({
 					id: 'normal',
 					name: 'Open',
 					default: true,
+					properties: {
+						attributes: { provides: ['Eyes_left_open'] },
+					},
 				},
 				{
 					id: 'closed',
 					name: 'Closed',
+					properties: {
+						attributes: { provides: ['Eyes_left_closed'] },
+					},
 				},
 				{
 					id: 'blind',
@@ -78,6 +84,7 @@ DefineBodypart({
 						effects: {
 							blind: 4.99,
 						},
+						attributes: { provides: ['Eyes_left_closed'] },
 					},
 				},
 			],
@@ -91,10 +98,16 @@ DefineBodypart({
 					id: 'normal',
 					name: 'Open',
 					default: true,
+					properties: {
+						attributes: { provides: ['Eyes_right_open'] },
+					},
 				},
 				{
 					id: 'closed',
 					name: 'Closed',
+					properties: {
+						attributes: { provides: ['Eyes_right_closed'] },
+					},
 				},
 				{
 					id: 'blind',
@@ -103,6 +116,7 @@ DefineBodypart({
 						effects: {
 							blind: 4.99,
 						},
+						attributes: { provides: ['Eyes_right_closed'] },
 					},
 				},
 			],

--- a/src/assets/body/eyes5/eyes5.asset.ts
+++ b/src/assets/body/eyes5/eyes5.asset.ts
@@ -47,14 +47,23 @@ DefineBodypart({
 					id: 'normal',
 					name: 'Open',
 					default: true,
+					properties: {
+						attributes: { provides: ['Eyes_left_open'] },
+					},
 				},
 				{
 					id: 'squint',
 					name: 'Squint',
+					properties: {
+						attributes: { provides: ['Eyes_left_open'] },
+					},
 				},
 				{
 					id: 'closed',
 					name: 'Closed',
+					properties: {
+						attributes: { provides: ['Eyes_left_closed'] },
+					},
 				},
 				{
 					id: 'blind',
@@ -63,6 +72,7 @@ DefineBodypart({
 						effects: {
 							blind: 4.99,
 						},
+						attributes: { provides: ['Eyes_left_closed'] },
 					},
 				},
 			],
@@ -76,14 +86,23 @@ DefineBodypart({
 					id: 'normal',
 					name: 'Open',
 					default: true,
+					properties: {
+						attributes: { provides: ['Eyes_right_open'] },
+					},
 				},
 				{
 					id: 'squint',
 					name: 'Squint',
+					properties: {
+						attributes: { provides: ['Eyes_right_open'] },
+					},
 				},
 				{
 					id: 'closed',
 					name: 'Closed',
+					properties: {
+						attributes: { provides: ['Eyes_right_closed'] },
+					},
 				},
 				{
 					id: 'blind',
@@ -92,6 +111,7 @@ DefineBodypart({
 						effects: {
 							blind: 4.99,
 						},
+						attributes: { provides: ['Eyes_right_closed'] },
 					},
 				},
 			],

--- a/src/assets/dresses/latex_catsuit/latex_catsuit.asset.ts
+++ b/src/assets/dresses/latex_catsuit/latex_catsuit.asset.ts
@@ -115,8 +115,12 @@ DefineAsset({
 					properties: {
 						attributes: {
 							provides: [
-								'Hand_item',
+								'Hand_cover',
 								'Gloves',
+							],
+							covers: [
+								'Hand_item',
+								'Hand_cover',
 							],
 						},
 					},
@@ -127,8 +131,12 @@ DefineAsset({
 					properties: {
 						attributes: {
 							provides: [
-								'Hand_item',
+								'Hand_cover',
 								'Gloves',
+							],
+							covers: [
+								'Hand_item',
+								'Hand_cover',
 							],
 						},
 						stateFlags: {

--- a/src/assets/gloves/gloves/gloves.asset.ts
+++ b/src/assets/gloves/gloves/gloves.asset.ts
@@ -23,6 +23,11 @@ DefineAsset({
 	attributes: {
 		provides: [
 			'Gloves',
+			'Hand_cover',
+		],
+		covers: [
+			'Hand_item',
+			'Hand_cover',
 		],
 	},
 	modules: {

--- a/src/attributes.ts
+++ b/src/attributes.ts
@@ -8,7 +8,7 @@ import { DefineResource } from './tools/resources.js';
 
 //#region Attribute definitions - an attribute defines a role
 
-const ATTRIBUTES_DEFINITION_BASE = {
+const ATTRIBUTES_DEFINITION_BASE = DefineAttributes({
 	// Bodypart attributes
 	Body_base: {
 		name: 'Base body',
@@ -83,6 +83,30 @@ const ATTRIBUTES_DEFINITION_BASE = {
 		},
 		icon: 'eye',
 		useAsAssetPreference: false,
+	},
+	Eyes_right_open: {
+		name: 'Open right eye',
+		description: 'A right eye, that is open',
+		useAsAssetPreference: false,
+		parentAttributes: ['Eyes'],
+	},
+	Eyes_left_open: {
+		name: 'Open left eye',
+		description: 'A left eye, that is open',
+		useAsAssetPreference: false,
+		parentAttributes: ['Eyes'],
+	},
+	Eyes_right_closed: {
+		name: 'Closed right eye',
+		description: 'A right eye, that is closed',
+		useAsAssetPreference: false,
+		parentAttributes: ['Eyes'],
+	},
+	Eyes_left_closed: {
+		name: 'Closed left eye',
+		description: 'A left eye, that is closed',
+		useAsAssetPreference: false,
+		parentAttributes: ['Eyes'],
 	},
 	Nose: {
 		name: 'Nose',
@@ -721,21 +745,27 @@ const ATTRIBUTES_DEFINITION_BASE = {
 		description: 'A fix point behind the head to which a gag can be secured',
 		useAsAssetPreference: false,
 	},
-} as const satisfies Record<string, AssetRepoAttributeDefinition>;
+});
 
 //#endregion
 
-export type AttributeNames = (keyof typeof ATTRIBUTES_DEFINITION_BASE) & string;
-export const ATTRIBUTES_DEFINITION: Readonly<Record<AttributeNames, AssetRepoAttributeDefinition>> = ATTRIBUTES_DEFINITION_BASE;
+function DefineAttributes<const TAttributeName extends string>(
+	definitions: Record<TAttributeName, NoInfer<AssetRepoAttributeDefinition<TAttributeName>>>,
+): Readonly<Record<TAttributeName, AssetRepoAttributeDefinition<TAttributeName>>> {
+	return definitions;
+}
 
-type AssetRepoAttributeDefinition = AssetAttributeDefinition & {
-	parentAttributes?: readonly string[];
+export type AttributeNames = (keyof typeof ATTRIBUTES_DEFINITION_BASE) & string;
+export const ATTRIBUTES_DEFINITION: Readonly<Record<AttributeNames, AssetRepoAttributeDefinition<AttributeNames>>> = ATTRIBUTES_DEFINITION_BASE;
+
+type AssetRepoAttributeDefinition<TAttributes> = AssetAttributeDefinition & {
+	parentAttributes?: readonly TAttributes[];
 };
 
 export function LoadAttributes(): Record<AttributeNames, AssetAttributeDefinition> {
 	const logger = GetLogger('LoadAttributes');
-	const result: Record<AttributeNames, AssetRepoAttributeDefinition> = cloneDeep(ATTRIBUTES_DEFINITION);
-	const unknownAttributeLookup: Partial<Readonly<Record<string, AssetRepoAttributeDefinition>>> = result;
+	const result: Record<AttributeNames, AssetRepoAttributeDefinition<AttributeNames>> = cloneDeep(ATTRIBUTES_DEFINITION);
+	const unknownAttributeLookup: Partial<Readonly<Record<string, AssetRepoAttributeDefinition<AttributeNames>>>> = result;
 
 	for (const [id, attribute] of Object.entries(result)) {
 		for (const parentAttribute of (attribute.parentAttributes ?? [])) {


### PR DESCRIPTION
## References

_None_

## About The Pull Request

n/a

## Changelog

Authored by: Claudia

```md
Assets:
- Reworked hand related attributes on applicable assets for more consistency.
- Added new attributes for open or closed eyes for an upcoming new feature.
- Fixed an attribute issue that would hide the latex cat suit when wearing an armbinder.
```

## Checklist

<!-- Checklist for you to make sure you didn't miss something -->
- [x] The change has been tested locally
- [x] Licensing information and credits were filled in/modified for added/modified assets
- [x] I understand this change is licensed based on [Pandora's Asset Licensing](https://github.com/Project-Pandora-Game/pandora-assets/blob/master/ASSET_LICENSING.md) information
