### PR TITLE
[FIX] Typo in catsuit layer config

### DIFF
--- a/src/assets/dresses/latex_catsuit/graphics.json
+++ b/src/assets/dresses/latex_catsuit/graphics.json
@@ -717,7 +717,7 @@
 								{
 									"module": "addOns",
 									"operator": "!=",
-									"value": "sock"
+									"value": "socks"
 								}
 							]
 						]
@@ -1050,7 +1050,7 @@
 								{
 									"module": "addOns",
 									"operator": "!=",
-									"value": "sock"
+									"value": "socks"
 								}
 							]
 						]
@@ -1524,7 +1524,7 @@
 								{
 									"module": "addOns",
 									"operator": "!=",
-									"value": "sock"
+									"value": "socks"
 								}
 							]
 						]
@@ -1857,7 +1857,7 @@
 								{
 									"module": "addOns",
 									"operator": "!=",
-									"value": "sock"
+									"value": "socks"
 								}
 							]
 						]


### PR DESCRIPTION
## References

_None_

## About The Pull Request

Fixed a typo in the catsuit's layer config that sometimes rendered the wrong images

## Changelog

Authored by: Sandrine

```md
Assets:
- [Latex catsuit] Layer config fixed
```

## Checklist

<!-- Checklist for you to make sure you didn't miss something -->
- [X] The change has been tested locally
- [X] Licensing information and credits were filled in/modified for added/modified assets
- [X] I understand this change is licensed based on [Pandora's Asset Licensing](https://github.com/Project-Pandora-Game/pandora-assets/blob/master/ASSET_LICENSING.md) information
