### PR TITLE
[ADD] Missing wig definitions

### DIFF
--- a/src/assets/body/back_hair_pigtails/back_hair_pigtails.asset.ts
+++ b/src/assets/body/back_hair_pigtails/back_hair_pigtails.asset.ts
@@ -1,7 +1,7 @@
 import { CreateHairColor } from '../../../helpers/hair_base.ts';
 const { colorization, modules } = CreateHairColor(false);
 
-DefineBodypart({
+const bodypart = DefineBodypart({
 	name: 'Pigtails',
 	bodypart: 'backhair',
 	graphics: 'graphics.json',
@@ -55,3 +55,21 @@ DefineBodypart({
 		],
 	},
 });
+
+DefineAsset({
+	...bodypart, // Reuse most of bodypart definition
+	id: 'body/back_hair_pigtails/wig',
+	name: 'Pigtails wig',
+	size: 'small',
+	attributes: {
+		provides: [
+			'Wig',
+			'Wig_back',
+		],
+		hides: [
+			'Hair_back',
+			'Hair_extension',
+		],
+	},
+});
+

--- a/src/assets/body/back_hair_ponytail/back_hair_ponytail.asset.ts
+++ b/src/assets/body/back_hair_ponytail/back_hair_ponytail.asset.ts
@@ -2,7 +2,7 @@ import { ItemInteractionType } from 'pandora-common';
 import { CreateHairColor } from '../../../helpers/hair_base.ts';
 const { colorization, modules } = CreateHairColor(true);
 
-DefineBodypart({
+const bodypart = DefineBodypart({
 	name: 'Ponytail',
 	bodypart: 'backhair',
 	graphics: 'graphics.json',
@@ -49,6 +49,23 @@ DefineBodypart({
 				editedBy: 'ClaudiaMia & SandrinePDR',
 				license: 'Pandora-Use-Only-v1-or-later',
 			},
+		],
+	},
+});
+
+DefineAsset({
+	...bodypart, // Reuse most of bodypart definition
+	id: 'body/back_hair_ponytail/wig',
+	name: 'Ponytail wig',
+	size: 'small',
+	attributes: {
+		provides: [
+			'Wig',
+			'Wig_back',
+		],
+		hides: [
+			'Hair_back',
+			'Hair_extension',
 		],
 	},
 });

--- a/src/assets/body/back_hair_twintails/back_hair_twintails.asset.ts
+++ b/src/assets/body/back_hair_twintails/back_hair_twintails.asset.ts
@@ -1,7 +1,7 @@
 import { CreateHairColor } from '../../../helpers/hair_base.ts';
 const { colorization, modules } = CreateHairColor(false);
 
-DefineBodypart({
+const bodypart = DefineBodypart({
 	name: 'Twintails',
 	bodypart: 'backhair',
 	graphics: 'graphics.json',
@@ -51,6 +51,23 @@ DefineBodypart({
 				editedBy: 'ClaudiaMia',
 				license: 'Pandora-Use-Only-v1-or-later',
 			},
+		],
+	},
+});
+
+DefineAsset({
+	...bodypart, // Reuse most of bodypart definition
+	id: 'body/back_twintails/wig',
+	name: 'Twintails wig',
+	size: 'small',
+	attributes: {
+		provides: [
+			'Wig',
+			'Wig_back',
+		],
+		hides: [
+			'Hair_back',
+			'Hair_extension',
 		],
 	},
 });

--- a/src/assets/body/back_hair_twintails_long/back_hair_twintails_long.asset.ts
+++ b/src/assets/body/back_hair_twintails_long/back_hair_twintails_long.asset.ts
@@ -1,7 +1,7 @@
 import { CreateHairColor } from '../../../helpers/hair_base.ts';
 const { colorization, modules } = CreateHairColor(false);
 
-DefineBodypart({
+const bodypart = DefineBodypart({
 	name: 'Long Twintails',
 	bodypart: 'backhair',
 	graphics: 'graphics.json',
@@ -55,3 +55,21 @@ DefineBodypart({
 		],
 	},
 });
+
+DefineAsset({
+	...bodypart, // Reuse most of bodypart definition
+	id: 'body/back_hair_twintails_long/wig',
+	name: 'Long twintails wig',
+	size: 'small',
+	attributes: {
+		provides: [
+			'Wig',
+			'Wig_back',
+		],
+		hides: [
+			'Hair_back',
+			'Hair_extension',
+		],
+	},
+});
+


### PR DESCRIPTION
## References

_None_

## About The Pull Request

Added the missing wig definitions to the following hairstyles 
- pigtails
- ponytail
- twintails 
- long twintails 

## Changelog

Authored by: Sandrine

```md
Assets:
- [Pigtails, Ponytail, Twintails, Long Twintails] Now usable as wigs
```

## Checklist

<!-- Checklist for you to make sure you didn't miss something -->
- [X] The change has been tested locally
- [X] Licensing information and credits were filled in/modified for added/modified assets
- [X] I understand this change is licensed based on [Pandora's Asset Licensing](https://github.com/Project-Pandora-Game/pandora-assets/blob/master/ASSET_LICENSING.md) information
