### PR TITLE
[FIX] wrong point template used by the asian dress

### DIFF
--- a/src/assets/dresses/asian_dress/graphics.json
+++ b/src/assets/dresses/asian_dress/graphics.json
@@ -8,7 +8,7 @@
 			"height": 1500,
 			"type": "autoMesh",
 			"name": "front",
-			"points": "skirt_tight",
+			"points": "skirt_static",
 			"automeshTemplate": "aboveBody",
 			"graphicalLayers": [
 				{
@@ -88,7 +88,7 @@
 			"height": 1500,
 			"type": "autoMesh",
 			"name": "back",
-			"points": "skirt_tight",
+			"points": "skirt_static",
 			"automeshTemplate": "belowBody",
 			"graphicalLayers": [
 				{


### PR DESCRIPTION
## References

_none_

## About The Pull Request

n/a

## Changelog

Authored by: Clare & Claudia

```md
Assets:
- [Asian Dress] fixed the wrong point template used by the dress, as the dress is supposed to be open on both sides for the legs
```

## Checklist

<!-- Checklist for you to make sure you didn't miss something -->
- [x] The change has been tested locally
- [x] Licensing information and credits were filled in/modified for added/modified assets
- [x] I understand this change is licensed based on [Pandora's Asset Licensing](https://github.com/Project-Pandora-Game/pandora-assets/blob/master/ASSET_LICENSING.md) information
